### PR TITLE
chore: only run samples module during integration tests

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -51,6 +51,7 @@ javadoc)
     ;;
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
+      -P include-samples \
       -DtrimStackTrace=false \
       -Dclirr.skip=true \
       -Denforcer.skip=true \

--- a/pom.xml
+++ b/pom.xml
@@ -343,10 +343,7 @@
     </profile>
 
     <profile>
-      <id>samples-java8AndNewer</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
+      <id>include-samples</id>
       <modules>
         <module>samples</module>
       </modules>


### PR DESCRIPTION
By default, we won't run sample tests except during CI integration tests. To run them, you can enable the `include-samples` Maven profile.

This should allow releases to function -- a deploy is skipped completely if the last module in the reactor is configured to skip deployment.