### PR TITLE
chore: move autovalue version properties from the JDK 1.8 profile into the base profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,7 @@
     <threeten.version>1.4.1</threeten.version>
     <javax.annotations.version>1.3.2</javax.annotations.version>
     <animal-sniffer.version>1.18</animal-sniffer.version>
-    <google-api-services-bigquery.version>
-      v2-rev20191211-1.30.8
+    <google-api-services-bigquery.version>v2-rev20191211-1.30.8
     </google-api-services-bigquery.version>
     <auto-value.version>1.7</auto-value.version>
     <auto-value-annotations.version>${auto-value.version}</auto-value-annotations.version>
@@ -315,7 +314,6 @@
         <jdk>1.7</jdk>
       </activation>
       <properties>
-        <auto-value-annotations.version>1.7</auto-value-annotations.version>
         <auto-value.version>1.4</auto-value.version>
       </properties>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,7 @@
         <jdk>1.7</jdk>
       </activation>
       <properties>
+        <auto-value-annotations.version>1.7</auto-value-annotations.version>
         <auto-value.version>1.4</auto-value.version>
       </properties>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,12 @@
     <threeten.version>1.4.1</threeten.version>
     <javax.annotations.version>1.3.2</javax.annotations.version>
     <animal-sniffer.version>1.18</animal-sniffer.version>
-    <google-api-services-bigquery.version>v2-rev20191211-1.30.8
+    <google-api-services-bigquery.version>
+      v2-rev20191211-1.30.8
     </google-api-services-bigquery.version>
+    <auto-value.version>1.7</auto-value.version>
+    <auto-value-annotations.version>${auto-value.version}</auto-value-annotations.version>
+    <auto-service-annotations.version>1.0-rc6</auto-service-annotations.version>
   </properties>
 
   <dependencyManagement>
@@ -344,11 +348,6 @@
       <activation>
         <jdk>[1.8,)</jdk>
       </activation>
-      <properties>
-        <auto-value.version>1.7</auto-value.version>
-        <auto-value-annotations.version>${auto-value.version}</auto-value-annotations.version>
-        <auto-service-annotations.version>1.0-rc6</auto-service-annotations.version>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
This might help when users' build tools don't understand the Maven profiles configuration.