### PR TITLE
docs(samples): Include clustering fields and schema in CreateClusteredTable as part of the function arguments

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigquery/CreateClusteredTable.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/CreateClusteredTable.java
@@ -29,16 +29,25 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 
 public class CreateClusteredTable {
   public static void runCreateClusteredTable() {
     // TODO(developer): Replace these variables before running the sample.
     String datasetName = "MY_DATASET_NAME";
     String tableName = "MY_TABLE_NAME";
-    createClusteredTable(datasetName, tableName);
+    Schema schema =
+            Schema.of(
+                    Field.of("name", StandardSQLTypeName.STRING),
+                    Field.of("post_abbr", StandardSQLTypeName.STRING),
+                    Field.of("date", StandardSQLTypeName.DATE));
+    createClusteredTable(datasetName, tableName,
+            schema, ImmutableList.of("name", "post_abbr"));
   }
 
-  public static void createClusteredTable(String datasetName, String tableName) {
+  public static void createClusteredTable(
+          String datasetName, String tableName,
+          Schema schema, List<String> clusteringFields) {
     try {
       // Initialize client that will be used to send requests. This client only needs to be created
       // once, and can be reused for multiple requests.
@@ -47,15 +56,10 @@ public class CreateClusteredTable {
       TableId tableId = TableId.of(datasetName, tableName);
 
       TimePartitioning partitioning = TimePartitioning.of(TimePartitioning.Type.DAY);
-
-      Schema schema =
-          Schema.of(
-              Field.of("name", StandardSQLTypeName.STRING),
-              Field.of("post_abbr", StandardSQLTypeName.STRING),
-              Field.of("date", StandardSQLTypeName.DATE));
-
+      // Clustering fields will be consisted of fields mentioned in the schema.
+      // As of now, another condition is that the table should be partitioned.
       Clustering clustering =
-          Clustering.newBuilder().setFields(ImmutableList.of("name", "post_abbr")).build();
+          Clustering.newBuilder().setFields(clusteringFields).build();
 
       StandardTableDefinition tableDefinition =
           StandardTableDefinition.newBuilder()

--- a/samples/snippets/src/test/java/com/example/bigquery/CreateClusteredTableIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/CreateClusteredTableIT.java
@@ -19,6 +19,10 @@ package com.example.bigquery;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import org.junit.After;
@@ -58,8 +62,14 @@ public class CreateClusteredTableIT {
   @Test
   public void createClusteredTable() {
     String tableName = "MY_CLUSTERED_TABLE";
+    Schema schema =
+            Schema.of(
+                    Field.of("name", StandardSQLTypeName.STRING),
+                    Field.of("post_abbr", StandardSQLTypeName.STRING),
+                    Field.of("date", StandardSQLTypeName.DATE));
 
-    CreateClusteredTable.createClusteredTable(BIGQUERY_DATASET_NAME, tableName);
+    CreateClusteredTable.createClusteredTable(BIGQUERY_DATASET_NAME, tableName,
+            schema, ImmutableList.of("name", "post_abbr"));
 
     assertThat(bout.toString()).contains("Clustered table created successfully");
 


### PR DESCRIPTION
As of the current version we can see that the schema and clustering fields
is already defined in the functions, however by passing it as the arguments
engineer can easily change the schema and clustering fields in the IT test
thus enable them to understand more about the concept.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #380  ☕️
