### PR TITLE
docs(samples): Include clustering fields and schema in LoadTableClusteredIT as part of the function arguments

### DIFF
--- a/samples/snippets/src/test/java/com/example/bigquery/LoadTableClusteredIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/LoadTableClusteredIT.java
@@ -19,6 +19,10 @@ package com.example.bigquery;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import org.junit.After;
@@ -61,7 +65,14 @@ public class LoadTableClusteredIT {
 
     String tableName = "LOAD_CLUSTERED_TABLE_TEST";
 
-    LoadTableClustered.loadTableClustered(BIGQUERY_DATASET_NAME, tableName, sourceUri);
+    Schema schema =
+            Schema.of(
+                    Field.of("name", StandardSQLTypeName.STRING),
+                    Field.of("post_abbr", StandardSQLTypeName.STRING),
+                    Field.of("date", StandardSQLTypeName.DATE));
+
+    LoadTableClustered.loadTableClustered(BIGQUERY_DATASET_NAME, tableName, sourceUri,
+            schema, ImmutableList.of("name", "post_abbr"));
 
     assertThat(bout.toString())
         .contains("Data successfully loaded into clustered table during load job");


### PR DESCRIPTION
As of the current version we can see that the schema and clustering fields
is already defined in the functions, however by passing it as the arguments
engineer can easily change the schema and clustering fields in the IT test
thus enable them to understand more about the concept.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #381 ☕️
