### PR TITLE
docs(samples): Fix flaky test

### DIFF
--- a/samples/snippets/src/test/java/com/example/bigquery/UpdateTableExpirationIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/UpdateTableExpirationIT.java
@@ -19,8 +19,12 @@ package com.example.bigquery;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
@@ -58,8 +62,13 @@ public class UpdateTableExpirationIT {
 
   @Test
   public void updateTableExpiration() {
-    String tableName = "update_expiration_table";
-    CreateTable.createTable(BIGQUERY_DATASET_NAME, tableName, null);
+    String suffix = UUID.randomUUID().toString().replace('-', '_');
+    String tableName = "update_expiration_table_" + suffix;
+    Schema schema =
+            Schema.of(
+                    Field.of("stringField", StandardSQLTypeName.STRING),
+                    Field.of("booleanField", StandardSQLTypeName.BOOL));
+    CreateTable.createTable(BIGQUERY_DATASET_NAME, tableName, schema);
     Long newExpiration = TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS);
     UpdateTableExpiration.updateTableExpiration(BIGQUERY_DATASET_NAME, tableName, newExpiration);
     assertThat(bout.toString()).contains("Table expiration updated successfully");


### PR DESCRIPTION
We found that UpdateTableExpirationIT is flaky since during table creation the table is not created.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #393 ☕️
