### PR TITLE
fix: handle malformed backend responses for PolicyTag messages

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/PolicyTags.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/PolicyTags.java
@@ -60,6 +60,10 @@ public abstract class PolicyTags implements Serializable {
 
   static PolicyTags fromPb(
       com.google.api.services.bigquery.model.TableFieldSchema.PolicyTags tagPb) {
-    return newBuilder().setNames(tagPb.getNames()).build();
+    // Treat a PolicyTag message without a Names subfield as invalid.
+    if (tagPb.getNames() != null) {
+      return newBuilder().setNames(tagPb.getNames()).build();
+    }
+    return null;
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/PolicyTagsTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/PolicyTagsTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -44,6 +45,13 @@ public class PolicyTagsTest {
   public void testBuilder() {
     assertEquals(POLICIES, POLICY_TAGS.getNames());
     assertNotEquals(POLICY_TAGS, POLICIES);
+  }
+
+  @Test
+  public void testWithoutNames() {
+    com.google.api.services.bigquery.model.TableFieldSchema.PolicyTags PARTIALTAG =
+        new com.google.api.services.bigquery.model.TableFieldSchema.PolicyTags();
+    assertNull(PolicyTags.fromPb(PARTIALTAG));
   }
 
   @Test


### PR DESCRIPTION
When you delete a policy tag from a column in BigQuery, rather than
eliding the policyTag message entirely, it will return an empty
message (with no names field).  This change treats such responses
as equivalent to no PolicyTag message being present.


reported as internal issue: 160857208