### PR TITLE
Set policy tags to empty instead of null

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/PolicyTags.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/PolicyTags.java
@@ -60,10 +60,11 @@ public abstract class PolicyTags implements Serializable {
 
   static PolicyTags fromPb(
       com.google.api.services.bigquery.model.TableFieldSchema.PolicyTags tagPb) {
-    // Treat a PolicyTag message without a Names subfield as invalid.
+    Builder builder = newBuilder();
+    // Treat a PolicyTag message without a Names subfield as empty.
     if (tagPb.getNames() != null) {
-      return newBuilder().setNames(tagPb.getNames()).build();
+      builder = builder.setNames(tagPb.getNames());
     }
-    return null;
+    return builder.build();
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/PolicyTagsTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/PolicyTagsTest.java
@@ -51,7 +51,7 @@ public class PolicyTagsTest {
   public void testWithoutNames() {
     com.google.api.services.bigquery.model.TableFieldSchema.PolicyTags PARTIALTAG =
         new com.google.api.services.bigquery.model.TableFieldSchema.PolicyTags();
-    assertNull(PolicyTags.fromPb(PARTIALTAG));
+    assertNull(PolicyTags.fromPb(PARTIALTAG).getNames());
   }
 
   @Test


### PR DESCRIPTION
Currently when BigQuery returns policy tag object without names, the whole policy tag field is set to null, which is not consistent with the REST Api, this pull request changes the behaviour to return an instance with names set to null instead.

This change modifies a previous PR https://github.com/googleapis/java-bigquery/pull/522, that was created in response to my GCP support ticket, slightly tweaking the behaviour to make it more consistent with the REST api.

- [ ] ~Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!~ There is GCP issue instead. The case Id is 24194276
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] ~Appropriate docs were updated~ (if necessary)

