### PR TITLE
build: remove maintainer permission from repo config

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -43,7 +43,7 @@ permissionRules:
 # Team slug to add to repository permissions
 - team: api-bigquery
   # Access level required, one of push|pull|admin|maintain|triage
-  permission: maintain
+  permission: admin
 - team: yoshi-java
   permission: push
 - team: yoshi-admins


### PR DESCRIPTION
Turns out, the GitHub API cannot handle the `maintain` and `triage` permissions quite yet for teams.  We can set those manually, or switch to `admin`/`write`.  I bumped `api-bigquery` up to `admin here, but I'm open for whatever. 