### PR TITLE
feat: add connectionId support for external data sources

### DIFF
--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -5,11 +5,11 @@
   <difference>
     <differenceType>7013</differenceType>
     <className>com/google/cloud/bigquery/ExternalTableDefinition</className>
-    <method>public java.lang.String getConnectionId()</method>
+    <method>java.lang.String getConnectionId()</method>
   </difference>
   <difference>
     <differenceType>7013</differenceType>
     <className>com/google/cloud/bigquery/ExternalTableDefinition$Builder</className>
-    <method>public com.google.cloud.bigquery.ExternalTableDefinition$Builder setConnectionId(java.lang.String)</method>
+    <method>com.google.cloud.bigquery.ExternalTableDefinition$Builder setConnectionId(java.lang.String)</method>
   </difference>
 </differences>

--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <!-- TODO: REMOVE AFTER RELEASE OF CONNECTION_ID FEAT -->
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/bigquery/ExternalTableDefinition</className>
+    <method>public java.lang.String getConnectionId()</method>
+  </difference>
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/bigquery/ExternalTableDefinition$Builder</className>
+    <method>public com.google.cloud.bigquery.ExternalTableDefinition$Builder setConnectionId(java.lang.String)</method>
+  </difference>
+</differences>

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ExternalTableDefinition.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ExternalTableDefinition.java
@@ -125,7 +125,7 @@ public abstract class ExternalTableDefinition extends TableDefinition {
     public abstract Builder setCompression(String compression);
 
     /**
-     * [Optional, Trusted Tester] Connection for external data source. The value may be {@code
+     * [Optional, Trusted Tester] connectionId for external data source. The value may be {@code
      * null}.
      */
     public abstract Builder setConnectionId(String connectionId);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ExternalTableDefinition.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ExternalTableDefinition.java
@@ -125,6 +125,12 @@ public abstract class ExternalTableDefinition extends TableDefinition {
     public abstract Builder setCompression(String compression);
 
     /**
+     * [Optional, Trusted Tester] Connection for external data source. The value may be {@code
+     * null}.
+     */
+    public abstract Builder setConnectionId(String connectionId);
+
+    /**
      * [Experimental] Sets detection of schema and format options automatically. Any option
      * specified explicitly will be honored.
      */
@@ -157,6 +163,16 @@ public abstract class ExternalTableDefinition extends TableDefinition {
    */
   @Nullable
   public abstract String getCompression();
+
+  /**
+   * Returns the connection ID used to connect to external data source.
+   *
+   * @see <a
+   *     href="https://cloud.google.com/bigquery/docs/reference/v2/tables#externalDataConfiguration">
+   *     ConnectionId</a>
+   */
+  @Nullable
+  public abstract String getConnectionId();
 
   /**
    * Returns whether BigQuery should allow extra values that are not represented in the table
@@ -248,6 +264,9 @@ public abstract class ExternalTableDefinition extends TableDefinition {
         new com.google.api.services.bigquery.model.ExternalDataConfiguration();
     if (getCompression() != null) {
       externalConfigurationPb.setCompression(getCompression());
+    }
+    if (getConnectionId() != null) {
+      externalConfigurationPb.setConnectionId(getConnectionId());
     }
     if (ignoreUnknownValues() != null) {
       externalConfigurationPb.setIgnoreUnknownValues(ignoreUnknownValues());
@@ -415,6 +434,9 @@ public abstract class ExternalTableDefinition extends TableDefinition {
         builder.setFormatOptions(FormatOptions.of(externalDataConfiguration.getSourceFormat()));
       }
       builder.setCompression(externalDataConfiguration.getCompression());
+      if (externalDataConfiguration.getConnectionId() != null) {
+        builder.setConnectionId(externalDataConfiguration.getConnectionId());
+      }
       builder.setIgnoreUnknownValues(externalDataConfiguration.getIgnoreUnknownValues());
       if (externalDataConfiguration.getCsvOptions() != null) {
         builder.setFormatOptions(CsvOptions.fromPb(externalDataConfiguration.getCsvOptions()));
@@ -451,6 +473,9 @@ public abstract class ExternalTableDefinition extends TableDefinition {
     }
     if (externalDataConfiguration.getCompression() != null) {
       builder.setCompression(externalDataConfiguration.getCompression());
+    }
+    if (externalDataConfiguration.getConnectionId() != null) {
+      builder.setConnectionId(externalDataConfiguration.getConnectionId());
     }
     if (externalDataConfiguration.getIgnoreUnknownValues() != null) {
       builder.setIgnoreUnknownValues(externalDataConfiguration.getIgnoreUnknownValues());

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ExternalTableDefinitionTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ExternalTableDefinitionTest.java
@@ -46,6 +46,7 @@ public class ExternalTableDefinitionTest {
   private static final Integer MAX_BAD_RECORDS = 42;
   private static final Boolean IGNORE_UNKNOWN_VALUES = true;
   private static final String COMPRESSION = "GZIP";
+  private static final String CONNECTION_ID = "123456789";
   private static final Boolean AUTODETECT = true;
   private static final CsvOptions CSV_OPTIONS = CsvOptions.newBuilder().build();
   private static final HivePartitioningOptions HIVE_PARTITIONING_OPTIONS =
@@ -56,6 +57,7 @@ public class ExternalTableDefinitionTest {
   private static final ExternalTableDefinition EXTERNAL_TABLE_DEFINITION =
       ExternalTableDefinition.newBuilder(SOURCE_URIS, TABLE_SCHEMA, CSV_OPTIONS)
           .setCompression(COMPRESSION)
+          .setConnectionId(CONNECTION_ID)
           .setIgnoreUnknownValues(IGNORE_UNKNOWN_VALUES)
           .setMaxBadRecords(MAX_BAD_RECORDS)
           .setAutodetect(AUTODETECT)
@@ -67,10 +69,19 @@ public class ExternalTableDefinitionTest {
     compareExternalTableDefinition(
         EXTERNAL_TABLE_DEFINITION, EXTERNAL_TABLE_DEFINITION.toBuilder().build());
     ExternalTableDefinition externalTableDefinition =
-        EXTERNAL_TABLE_DEFINITION.toBuilder().setCompression("NONE").build();
+        EXTERNAL_TABLE_DEFINITION
+            .toBuilder()
+            .setCompression("NONE")
+            .setConnectionId("00000")
+            .build();
     assertEquals("NONE", externalTableDefinition.getCompression());
+    assertEquals("00000", externalTableDefinition.getConnectionId());
     externalTableDefinition =
-        externalTableDefinition.toBuilder().setCompression(COMPRESSION).build();
+        externalTableDefinition
+            .toBuilder()
+            .setCompression(COMPRESSION)
+            .setConnectionId(CONNECTION_ID)
+            .build();
     compareExternalTableDefinition(EXTERNAL_TABLE_DEFINITION, externalTableDefinition);
   }
 
@@ -94,6 +105,7 @@ public class ExternalTableDefinitionTest {
   public void testBuilder() {
     assertEquals(TableDefinition.Type.EXTERNAL, EXTERNAL_TABLE_DEFINITION.getType());
     assertEquals(COMPRESSION, EXTERNAL_TABLE_DEFINITION.getCompression());
+    assertEquals(CONNECTION_ID, EXTERNAL_TABLE_DEFINITION.getConnectionId());
     assertEquals(CSV_OPTIONS, EXTERNAL_TABLE_DEFINITION.getFormatOptions());
     assertEquals(IGNORE_UNKNOWN_VALUES, EXTERNAL_TABLE_DEFINITION.ignoreUnknownValues());
     assertEquals(MAX_BAD_RECORDS, EXTERNAL_TABLE_DEFINITION.getMaxBadRecords());
@@ -119,6 +131,7 @@ public class ExternalTableDefinitionTest {
       ExternalTableDefinition expected, ExternalTableDefinition value) {
     assertEquals(expected, value);
     assertEquals(expected.getCompression(), value.getCompression());
+    assertEquals(expected.getConnectionId(), value.getConnectionId());
     assertEquals(expected.getFormatOptions(), value.getFormatOptions());
     assertEquals(expected.ignoreUnknownValues(), value.ignoreUnknownValues());
     assertEquals(expected.getMaxBadRecords(), value.getMaxBadRecords());


### PR DESCRIPTION
Add connecitonId to ExternalTableDefinition to allow external data source query through the BigQuery client.