### PR TITLE
chore(deps): reorder dependencies so http-client is before storage

### DIFF
--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -26,12 +26,12 @@
       <artifactId>google-cloud-core-http</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-storage</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>


### PR DESCRIPTION
google-http-client will update before it can be updated in google-cloud-storage (which also has a dependency on google-http-client). By making this version first, we ensure that any transitive dependency versions will take precedence from google-http-client directly.