### PR TITLE
ci: fix shell script "exec format error"

### DIFF
--- a/.kokoro/run_samples_resource_cleanup.sh
+++ b/.kokoro/run_samples_resource_cleanup.sh
@@ -1,4 +1,4 @@
-````#!/bin/bash
+#!/bin/bash
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Nightly samples cleanup job failed due to below error:

```
Executing: docker run --rm --interactive --network=host --privileged --volume=/var/run/docker.sock:/var/run/docker.sock --workdir=/tmpfs/src --entrypoint=github/java-bigquery/.kokoro/run_samples_resource_cleanup.sh --env-file=/tmpfs/tmp/tmpccr95nk7/envfile --volume=/tmpfs:/tmpfs gcr.io/cloud-devrel-kokoro-resources/java8
standard_init_linux.go:190: exec user process caused "exec format error"
```

This PR is to fix the above.