### PR TITLE
ci: enable secrete manager for nightly resource cleanup

### DIFF
--- a/.kokoro/nightly/samples.cfg
+++ b/.kokoro/nightly/samples.cfg
@@ -29,7 +29,7 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-docs-samples-service-account"
+  value: "java-docs-samples-service-account, java-bigquery-samples-secrets"
 }
 
 env_vars: {

--- a/.kokoro/run_samples_resource_cleanup.sh
+++ b/.kokoro/run_samples_resource_cleanup.sh
@@ -29,7 +29,7 @@ cd ${scriptDir}/..
 source ${scriptDir}/common.sh
 
 # Setup required env variables
-source ${KOKORO_GFILE_DIR}/bigquery_secrets.txt
+source ${KOKORO_GFILE_DIR}/secret_manager/java-bigquery-samples-secrets
 echo "********** Successfully Set All Environment Variables **********"
 
 # Activate service account


### PR DESCRIPTION
Fixes `github/java-bigquery/.kokoro/run_samples_resource_cleanup.sh: line 32: /tmpfs/src/gfile/bigquery_secrets.txt: No such file or directory` seen in Fusion build logs: https://g3c.corp.google.com/results/invocations/55fae1ae-eb61-4308-90e6-c2b17d08ccd5/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fjava-bigquery%2Fnightly%2Fsamples/log