### PR TITLE
ci: prepend kokoro root directory to the path to service-acct.json

### DIFF
--- a/.kokoro/run_samples_resource_cleanup.sh
+++ b/.kokoro/run_samples_resource_cleanup.sh
@@ -32,6 +32,11 @@ source ${scriptDir}/common.sh
 source ${KOKORO_GFILE_DIR}/secret_manager/java-bigquery-samples-secrets
 echo "********** Successfully Set All Environment Variables **********"
 
+# if GOOGLE_APPLICATION_CREDIENTIALS is specified as a relative path prepend Kokoro root directory onto it
+if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
+    export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
+fi
+
 # Activate service account
 gcloud auth activate-service-account \
     --key-file="$GOOGLE_APPLICATION_CREDENTIALS" \


### PR DESCRIPTION
Fixes ``` ERROR: (gcloud.auth.activate-service-account) Unable to read file [/tmpfs/src/gfile/service-acct.json]: [Errno 2] No such file or directory: '/tmpfs/src/gfile/service-acct.json' ```

Full trace: https://g3c.corp.google.com/results/invocations/a20c9009-fb3a-4f66-a6c1-11ad49a8db5b/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fjava-bigquery%2Fnightly%2Fsamples/log