### PR TITLE
ci: update Kokoro root directory

### DIFF
--- a/.kokoro/run_samples_resource_cleanup.sh
+++ b/.kokoro/run_samples_resource_cleanup.sh
@@ -34,7 +34,7 @@ echo "********** Successfully Set All Environment Variables **********"
 
 # if GOOGLE_APPLICATION_CREDIENTIALS is specified as a relative path prepend Kokoro root directory onto it
 if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
-    export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
+    export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/secret_manager/${GOOGLE_APPLICATION_CREDENTIALS})
 fi
 
 # Activate service account


### PR DESCRIPTION
To run nightly samples resource cleanup jobs.

Still observing:
```
ERROR: (gcloud.auth.activate-service-account) Unable to read file [/tmpfs/src/gfile/service-acct.json]: [Errno 2] No such file or directory: '/tmpfs/src/gfile/service-acct.json'
```

https://g3c.corp.google.com/results/invocations/cc95e6ae-5986-430d-b69e-ef87696ba02c/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fjava-bigquery%2Fnightly%2Fsamples/log