### PR TITLE
fix: make sure to fall back to old query path when query job is incomplete

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1268,13 +1268,8 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
     long numRows;
     Schema schema;
-    if ((results.getSchema() == null && results.getJobComplete()) || !results.getJobComplete()) {
-      JobId jobId = JobId.fromPb(results.getJobReference());
-      Job job = getJob(jobId, options);
-      TableResult tableResult = job.getQueryResults();
-      return tableResult;
-    } else {
-      schema = results.getSchema() == null ? null : Schema.fromPb(results.getSchema());
+    if (results.getJobComplete() && results.getSchema() != null) {
+      schema = Schema.fromPb(results.getSchema());
       if (results.getNumDmlAffectedRows() == null && results.getTotalRows() == null) {
         numRows = 0L;
       } else if (results.getNumDmlAffectedRows() != null) {
@@ -1282,6 +1277,11 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       } else {
         numRows = results.getTotalRows().longValue();
       }
+    } else {
+      JobId jobId = JobId.fromPb(results.getJobReference());
+      Job job = getJob(jobId, options);
+      TableResult tableResult = job.getQueryResults();
+      return tableResult;
     }
 
     if (results.getPageToken() != null) {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1268,7 +1268,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
     long numRows;
     Schema schema;
-    if (results.getSchema() == null && results.getJobComplete()) {
+    if ((results.getSchema() == null && results.getJobComplete()) || !results.getJobComplete()) {
       JobId jobId = JobId.fromPb(results.getJobReference());
       Job job = getJob(jobId, options);
       TableResult tableResult = job.getQueryResults();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1278,6 +1278,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
         numRows = results.getTotalRows().longValue();
       }
     } else {
+      // Query is long running (> 10s) and hasn't completed yet, or query completed but didn't
+      // return the schema, fallback. Some operations don't return the schema and can be optimized
+      // here, but this is left as future work.
       JobId jobId = JobId.fromPb(results.getJobReference());
       Job job = getJob(jobId, options);
       TableResult tableResult = job.getQueryResults();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1283,8 +1283,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       // here, but this is left as future work.
       JobId jobId = JobId.fromPb(results.getJobReference());
       Job job = getJob(jobId, options);
-      TableResult tableResult = job.getQueryResults();
-      return tableResult;
+      return job.getQueryResults();
     }
 
     if (results.getPageToken() != null) {

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -299,7 +299,6 @@ public class ITBigQueryTest {
   private static final String BUCKET = RemoteStorageHelper.generateBucketName();
   private static final TableId TABLE_ID = TableId.of(DATASET, "testing_table");
   private static final TableId TABLE_ID_DDL = TableId.of(DATASET, "ddl_testing_table");
-  private static final TableId TABLE_ID_DDL_SLOW = TableId.of(DATASET, "ddl_slow_testing_table");
   private static final TableId TABLE_ID_FASTQUERY = TableId.of(DATASET, "fastquery_testing_table");
   private static final TableId TABLE_ID_LARGE = TableId.of(DATASET, "large_data_testing_table");
   private static final String CSV_CONTENT = "StringValue1\nStringValue2\n";


### PR DESCRIPTION
When the query job takes more than 10s we must fall back to the old query path!

cc @epavan