### PR TITLE
feat: set requestId for fast query path in QueryRequestInfo instead of QueryJobConfiguration

### DIFF
--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -35,7 +35,6 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * Google BigQuery Query Job configuration. A Query Job runs a query against BigQuery data. Query
@@ -72,7 +71,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
   private final List<ConnectionProperty> connectionProperties;
   // maxResults is only used for fast query path
   private final Long maxResults;
-  private final String requestId;
 
   /**
    * Priority levels for a query. If not specified the priority is assumed to be {@link
@@ -123,7 +121,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
     private RangePartitioning rangePartitioning;
     private List<ConnectionProperty> connectionProperties;
     private Long maxResults;
-    private String requestId;
 
     private Builder() {
       super(Type.QUERY);
@@ -157,7 +154,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
       this.rangePartitioning = jobConfiguration.rangePartitioning;
       this.connectionProperties = jobConfiguration.connectionProperties;
       this.maxResults = jobConfiguration.maxResults;
-      this.requestId = jobConfiguration.requestId;
     }
 
     private Builder(com.google.api.services.bigquery.model.JobConfiguration configurationPb) {
@@ -625,11 +621,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
       return this;
     }
 
-    Builder setRequestId(String requestId) {
-      this.requestId = requestId;
-      return this;
-    }
-
     public QueryJobConfiguration build() {
       return new QueryJobConfiguration(this);
     }
@@ -672,7 +663,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
     this.rangePartitioning = builder.rangePartitioning;
     this.connectionProperties = builder.connectionProperties;
     this.maxResults = builder.maxResults;
-    this.requestId = builder.requestId;
   }
 
   /**
@@ -875,10 +865,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
     return maxResults;
   }
 
-  String getRequestId() {
-    return requestId;
-  }
-
   @Override
   public Builder toBuilder() {
     return new Builder(this);
@@ -1057,7 +1043,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
   /** Creates a builder for a BigQuery Query Job given the query to be run. */
   public static Builder newBuilder(String query) {
     checkArgument(!isNullOrEmpty(query), "Provided query is null or empty");
-    return new Builder().setQuery(query).setRequestId(UUID.randomUUID().toString());
+    return new Builder().setQuery(query);
   }
 
   /**

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -35,6 +35,7 @@ final class QueryRequestInfo {
   private final Long maxResults;
   private final String query;
   private final List<QueryParameter> queryParameters;
+  private final String requestId;
   private final Boolean useQueryCache;
   private final Boolean useLegacySql;
   private final String requestId;
@@ -49,6 +50,7 @@ final class QueryRequestInfo {
     this.maxResults = config.getMaxResults();
     this.query = config.getQuery();
     this.queryParameters = config.toPb().getQuery().getQueryParameters();
+    this.requestId = UUID.randomUUID().toString();
     this.useLegacySql = config.useLegacySql();
     this.useQueryCache = config.useQueryCache();
     this.requestId = config.getRequestId();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -23,6 +23,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 final class QueryRequestInfo {
 
@@ -38,7 +39,6 @@ final class QueryRequestInfo {
   private final String requestId;
   private final Boolean useQueryCache;
   private final Boolean useLegacySql;
-  private final String requestId;
 
   QueryRequestInfo(QueryJobConfiguration config) {
     this.config = config;
@@ -53,7 +53,6 @@ final class QueryRequestInfo {
     this.requestId = UUID.randomUUID().toString();
     this.useLegacySql = config.useLegacySql();
     this.useQueryCache = config.useQueryCache();
-    this.requestId = config.getRequestId();
   }
 
   boolean isFastQuerySupported() {

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -1899,6 +1899,14 @@ public class BigQueryImplTest {
       assertThat(row.get(0).getBooleanValue()).isFalse();
       assertThat(row.get(1).getLongValue()).isEqualTo(1);
     }
+
+    QueryRequest requestPb = requestPbCapture.getValue();
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.getQuery(), requestPb.getQuery());
+    assertEquals(
+        QUERY_JOB_CONFIGURATION_FOR_QUERY.getDefaultDataset().getDataset(),
+        requestPb.getDefaultDataset().getDatasetId());
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.useQueryCache(), requestPb.getUseQueryCache());
+
     verify(bigqueryRpcMock).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 
@@ -1944,6 +1952,14 @@ public class BigQueryImplTest {
     assertTrue(result.hasNextPage());
     assertNotNull(result.getNextPageToken());
     assertNotNull(result.getNextPage());
+
+    QueryRequest requestPb = requestPbCapture.getValue();
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.getQuery(), requestPb.getQuery());
+    assertEquals(
+        QUERY_JOB_CONFIGURATION_FOR_QUERY.getDefaultDataset().getDataset(),
+        requestPb.getDefaultDataset().getDatasetId());
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.useQueryCache(), requestPb.getUseQueryCache());
+
     verify(bigqueryRpcMock).getJob(PROJECT, JOB, null, EMPTY_RPC_OPTIONS);
     verify(bigqueryRpcMock)
         .listTableData(
@@ -2000,6 +2016,13 @@ public class BigQueryImplTest {
       assertThat(row.get(0).getBooleanValue()).isFalse();
       assertThat(row.get(1).getLongValue()).isEqualTo(1);
     }
+
+    QueryRequest requestPb = requestPbCapture.getValue();
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.getQuery(), requestPb.getQuery());
+    assertEquals(
+        QUERY_JOB_CONFIGURATION_FOR_QUERY.getDefaultDataset().getDataset(),
+        requestPb.getDefaultDataset().getDatasetId());
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.useQueryCache(), requestPb.getUseQueryCache());
 
     verify(bigqueryRpcMock).queryRpc(eq(PROJECT), requestPbCapture.capture());
     verify(bigqueryRpcMock).getJob(PROJECT, JOB, null, EMPTY_RPC_OPTIONS);
@@ -2421,6 +2444,13 @@ public class BigQueryImplTest {
     } catch (BigQueryException ex) {
       assertEquals(Lists.transform(errorProtoList, BigQueryError.FROM_PB_FUNCTION), ex.getErrors());
     }
+
+    QueryRequest requestPb = requestPbCapture.getValue();
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.getQuery(), requestPb.getQuery());
+    assertEquals(
+        QUERY_JOB_CONFIGURATION_FOR_QUERY.getDefaultDataset().getDataset(),
+        requestPb.getDefaultDataset().getDatasetId());
+    assertEquals(QUERY_JOB_CONFIGURATION_FOR_QUERY.useQueryCache(), requestPb.getUseQueryCache());
     verify(bigqueryRpcMock).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -1885,9 +1885,7 @@ public class BigQueryImplTest {
             .setTotalBytesProcessed(42L)
             .setTotalRows(BigInteger.valueOf(1L));
 
-    QueryRequestInfo requestInfo = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_FOR_QUERY);
-
-    when(bigqueryRpcMock.queryRpc(PROJECT, requestInfo.toPb())).thenReturn(queryResponsePb);
+    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture())).thenReturn(queryResponsePb);
 
     bigquery = options.getService();
     TableResult result = bigquery.query(QUERY_JOB_CONFIGURATION_FOR_QUERY);
@@ -1900,7 +1898,7 @@ public class BigQueryImplTest {
       assertThat(row.get(0).getBooleanValue()).isFalse();
       assertThat(row.get(1).getLongValue()).isEqualTo(1);
     }
-    verify(bigqueryRpcMock).queryRpc(PROJECT, requestInfo.toPb());
+    verify(bigqueryRpcMock).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 
   @Test
@@ -1937,8 +1935,7 @@ public class BigQueryImplTest {
             .setTotalBytesProcessed(42L)
             .setTotalRows(BigInteger.valueOf(1L));
 
-    QueryRequestInfo requestInfo = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_FOR_QUERY);
-    when(bigqueryRpcMock.queryRpc(PROJECT, requestInfo.toPb())).thenReturn(queryResponsePb);
+    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture())).thenReturn(queryResponsePb);
 
     bigquery = options.getService();
     TableResult result = bigquery.query(QUERY_JOB_CONFIGURATION_FOR_QUERY);
@@ -1952,7 +1949,7 @@ public class BigQueryImplTest {
             DATASET,
             TABLE,
             BigQueryImpl.optionMap(BigQuery.TableDataListOption.pageToken(CURSOR)));
-    verify(bigqueryRpcMock).queryRpc(PROJECT, requestInfo.toPb());
+    verify(bigqueryRpcMock).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 
   @Test
@@ -1983,10 +1980,7 @@ public class BigQueryImplTest {
             .setTotalRows(BigInteger.valueOf(1L))
             .setSchema(TABLE_SCHEMA.toPb());
 
-    QueryRequestInfo requestInfo = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_FOR_QUERY);
-    QueryRequest requestPb = requestInfo.toPb();
-
-    when(bigqueryRpcMock.queryRpc(PROJECT, requestPb)).thenReturn(queryResponsePb);
+    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture())).thenReturn(queryResponsePb);
     responseJob.getConfiguration().getQuery().setDestinationTable(TABLE_ID.toPb());
     when(bigqueryRpcMock.getJob(PROJECT, JOB, null, EMPTY_RPC_OPTIONS)).thenReturn(responseJob);
     when(bigqueryRpcMock.getQueryResults(
@@ -2004,7 +1998,7 @@ public class BigQueryImplTest {
       assertThat(row.get(1).getLongValue()).isEqualTo(1);
     }
 
-    verify(bigqueryRpcMock).queryRpc(PROJECT, requestInfo.toPb());
+    verify(bigqueryRpcMock).queryRpc(eq(PROJECT), requestPbCapture.capture());
     verify(bigqueryRpcMock).getJob(PROJECT, JOB, null, EMPTY_RPC_OPTIONS);
     verify(bigqueryRpcMock)
         .getQueryResults(
@@ -2415,10 +2409,7 @@ public class BigQueryImplTest {
             .setPageToken(null)
             .setErrors(errorProtoList);
 
-    QueryRequestInfo requestInfo = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_FOR_QUERY);
-    QueryRequest requestPb = requestInfo.toPb();
-
-    when(bigqueryRpcMock.queryRpc(PROJECT, requestPb)).thenReturn(responsePb);
+    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture())).thenReturn(responsePb);
 
     bigquery = options.getService();
     try {
@@ -2427,7 +2418,7 @@ public class BigQueryImplTest {
     } catch (BigQueryException ex) {
       assertEquals(Lists.transform(errorProtoList, BigQueryError.FROM_PB_FUNCTION), ex.getErrors());
     }
-    verify(bigqueryRpcMock).queryRpc(PROJECT, requestPb);
+    verify(bigqueryRpcMock).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -2287,9 +2287,6 @@ public class BigQueryImplTest {
             .setTotalRows(BigInteger.valueOf(1L))
             .setSchema(TABLE_SCHEMA.toPb());
 
-    QueryRequestInfo requestInfo = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_FOR_QUERY);
-    QueryRequest requestPb = requestInfo.toPb();
-
     when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture()))
         .thenThrow(new BigQueryException(500, "InternalError"))
         .thenThrow(new BigQueryException(502, "Bad Gateway"))
@@ -2310,13 +2307,13 @@ public class BigQueryImplTest {
 
     List<QueryRequest> allRequests = requestPbCapture.getAllValues();
     boolean idempotent = true;
-    String requestId = requestPb.getRequestId();
+    String firstRequestId = allRequests.get(0).getRequestId();
     for (QueryRequest request : allRequests) {
-      idempotent = request.getRequestId().equals(requestId);
+      idempotent = request.getRequestId().equals(firstRequestId);
     }
     assertTrue(idempotent);
 
-    verify(bigqueryRpcMock, times(5)).queryRpc(PROJECT, requestPb);
+    verify(bigqueryRpcMock, times(5)).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 
   @Test
@@ -2330,9 +2327,6 @@ public class BigQueryImplTest {
             .setTotalBytesProcessed(42L)
             .setNumDmlAffectedRows(1L)
             .setSchema(TABLE_SCHEMA.toPb());
-
-    QueryRequestInfo requestInfo = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_FOR_DMLQUERY);
-    QueryRequest requestPb = requestInfo.toPb();
 
     when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture()))
         .thenThrow(new BigQueryException(500, "InternalError"))
@@ -2354,13 +2348,13 @@ public class BigQueryImplTest {
 
     List<QueryRequest> allRequests = requestPbCapture.getAllValues();
     boolean idempotent = true;
-    String requestId = requestPb.getRequestId();
+    String firstRequestId = allRequests.get(0).getRequestId();
     for (QueryRequest request : allRequests) {
-      idempotent = request.getRequestId().equals(requestId);
+      idempotent = request.getRequestId().equals(firstRequestId);
     }
     assertTrue(idempotent);
 
-    verify(bigqueryRpcMock, times(5)).queryRpc(PROJECT, requestPb);
+    verify(bigqueryRpcMock, times(5)).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 
   @Test
@@ -2373,9 +2367,6 @@ public class BigQueryImplTest {
             .setPageToken(null)
             .setTotalBytesProcessed(42L)
             .setSchema(TABLE_SCHEMA.toPb());
-
-    QueryRequestInfo requestInfo = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_FOR_DDLQUERY);
-    QueryRequest requestPb = requestInfo.toPb();
 
     when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture()))
         .thenThrow(new BigQueryException(500, "InternalError"))
@@ -2397,13 +2388,13 @@ public class BigQueryImplTest {
 
     List<QueryRequest> allRequests = requestPbCapture.getAllValues();
     boolean idempotent = true;
-    String requestId = requestPb.getRequestId();
+    String firstRequestId = allRequests.get(0).getRequestId();
     for (QueryRequest request : allRequests) {
-      idempotent = request.getRequestId().equals(requestId);
+      idempotent = request.getRequestId().equals(firstRequestId);
     }
     assertTrue(idempotent);
 
-    verify(bigqueryRpcMock, times(5)).queryRpc(PROJECT, requestPb);
+    verify(bigqueryRpcMock, times(5)).queryRpc(eq(PROJECT), requestPbCapture.capture());
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -1885,7 +1885,8 @@ public class BigQueryImplTest {
             .setTotalBytesProcessed(42L)
             .setTotalRows(BigInteger.valueOf(1L));
 
-    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture())).thenReturn(queryResponsePb);
+    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture()))
+        .thenReturn(queryResponsePb);
 
     bigquery = options.getService();
     TableResult result = bigquery.query(QUERY_JOB_CONFIGURATION_FOR_QUERY);
@@ -1935,7 +1936,8 @@ public class BigQueryImplTest {
             .setTotalBytesProcessed(42L)
             .setTotalRows(BigInteger.valueOf(1L));
 
-    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture())).thenReturn(queryResponsePb);
+    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture()))
+        .thenReturn(queryResponsePb);
 
     bigquery = options.getService();
     TableResult result = bigquery.query(QUERY_JOB_CONFIGURATION_FOR_QUERY);
@@ -1980,7 +1982,8 @@ public class BigQueryImplTest {
             .setTotalRows(BigInteger.valueOf(1L))
             .setSchema(TABLE_SCHEMA.toPb());
 
-    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture())).thenReturn(queryResponsePb);
+    when(bigqueryRpcMock.queryRpc(eq(PROJECT), requestPbCapture.capture()))
+        .thenReturn(queryResponsePb);
     responseJob.getConfiguration().getQuery().setDestinationTable(TABLE_ID.toPb());
     when(bigqueryRpcMock.getJob(PROJECT, JOB, null, EMPTY_RPC_OPTIONS)).thenReturn(responseJob);
     when(bigqueryRpcMock.getQueryResults(

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigquery;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.services.bigquery.model.QueryRequest;
@@ -31,7 +32,6 @@ import org.junit.Test;
 
 public class QueryRequestInfoTest {
 
-  private static final String TEST_PROJECT_ID = "test-project-id";
   private static final String QUERY = "BigQuery SQL";
   private static final DatasetId DATASET_ID = DatasetId.of("dataset");
   private static final TableId TABLE_ID = TableId.of("dataset", "table");
@@ -166,8 +166,7 @@ public class QueryRequestInfoTest {
   }
 
   private void compareQueryRequestInfo(QueryRequestInfo expected, QueryRequestInfo actual) {
-    assertEquals(expected, actual);
-    assertEquals(expected.hashCode(), actual.hashCode());
-    assertEquals(expected.toString(), actual.toString());
+    // requestId are expected to be different
+    assertThat(actual).isEqualToIgnoringGivenFields(expected, "requestId");
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1776,6 +1776,15 @@ public class ITBigQueryTest {
     assertNull(result.getNextPageToken());
     assertFalse(result.hasNextPage());
 
+    // running the same QueryJobConfiguration with the same query again
+    TableResult result1Duplicate = bigquery.query(config);
+    assertEquals(QUERY_RESULT_SCHEMA, result1Duplicate.getSchema());
+    assertEquals(2, result.getTotalRows());
+    assertNull(result1Duplicate.getNextPage());
+    assertNull(result1Duplicate.getNextPageToken());
+    assertFalse(result1Duplicate.hasNextPage());
+
+    // running a new QueryJobConfiguration with the same query
     QueryJobConfiguration config2 =
         QueryJobConfiguration.newBuilder(query).setDefaultDataset(DatasetId.of(DATASET)).build();
     TableResult result2 = bigquery.query(config2);

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
         <version>1.113.4</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <!-- use 2.9.1 for Java 7 projects -->
+        <version>2.9.1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
As requested @epavan