### PR TITLE
chore: add env var for changing cloud-samples-data bucket

### DIFF
--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -121,6 +121,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -148,6 +149,8 @@ public class ITBigQueryTest {
   private static final String ROUTINE_DATASET = RemoteBigQueryHelper.generateDatasetName();
   private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
   private static final String RANDOM_ID = UUID.randomUUID().toString().substring(0, 8);
+  private static final String CLOUD_SAMPLES_DATA =
+      Optional.ofNullable(System.getenv("CLOUD_SAMPLES_DATA_BUCKET")).orElse("cloud-samples-data");
   private static final Map<String, String> LABELS =
       ImmutableMap.of(
           "example-label1", "example-value1",
@@ -1707,9 +1710,10 @@ public class ITBigQueryTest {
   @Test
   public void testQueryExternalHivePartitioningOptionAutoLayout() throws InterruptedException {
     String tableName = "test_queryexternalhivepartition_autolayout_table";
-    String sourceUri = "gs://cloud-samples-data/bigquery/hive-partitioning-samples/autolayout/*";
+    String sourceUri =
+        "gs://" + CLOUD_SAMPLES_DATA + "/bigquery/hive-partitioning-samples/autolayout/*";
     String sourceUriPrefix =
-        "gs://cloud-samples-data/bigquery/hive-partitioning-samples/autolayout/";
+        "gs://" + CLOUD_SAMPLES_DATA + "/bigquery/hive-partitioning-samples/autolayout/";
     HivePartitioningOptions hivePartitioningOptions =
         HivePartitioningOptions.newBuilder()
             .setMode("AUTO")
@@ -1737,9 +1741,10 @@ public class ITBigQueryTest {
   @Test
   public void testQueryExternalHivePartitioningOptionCustomLayout() throws InterruptedException {
     String tableName = "test_queryexternalhivepartition_customlayout_table";
-    String sourceUri = "gs://cloud-samples-data/bigquery/hive-partitioning-samples/customlayout/*";
-    String sourceUriPrefix =
-        "gs://cloud-samples-data/bigquery/hive-partitioning-samples/customlayout/{pkey:STRING}/";
+    String sourceUri =
+        "gs://" + CLOUD_SAMPLES_DATA + "/bigquery/hive-partitioning-samples/customlayout/*";
+    String sourceUriPrefix = "gs://" + CLOUD_SAMPLES_DATA +
+        "/bigquery/hive-partitioning-samples/customlayout/{pkey:STRING}/";
     HivePartitioningOptions hivePartitioningOptions =
         HivePartitioningOptions.newBuilder()
             .setMode("CUSTOM")

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1743,8 +1743,10 @@ public class ITBigQueryTest {
     String tableName = "test_queryexternalhivepartition_customlayout_table";
     String sourceUri =
         "gs://" + CLOUD_SAMPLES_DATA + "/bigquery/hive-partitioning-samples/customlayout/*";
-    String sourceUriPrefix = "gs://" + CLOUD_SAMPLES_DATA +
-        "/bigquery/hive-partitioning-samples/customlayout/{pkey:STRING}/";
+    String sourceUriPrefix =
+        "gs://"
+            + CLOUD_SAMPLES_DATA
+            + "/bigquery/hive-partitioning-samples/customlayout/{pkey:STRING}/";
     HivePartitioningOptions hivePartitioningOptions =
         HivePartitioningOptions.newBuilder()
             .setMode("CUSTOM")

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -102,6 +102,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -121,7 +122,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -150,7 +150,7 @@ public class ITBigQueryTest {
   private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
   private static final String RANDOM_ID = UUID.randomUUID().toString().substring(0, 8);
   private static final String CLOUD_SAMPLES_DATA =
-      Optional.ofNullable(System.getenv("CLOUD_SAMPLES_DATA_BUCKET")).orElse("cloud-samples-data");
+      Optional.fromNullable(System.getenv("CLOUD_SAMPLES_DATA_BUCKET")).or("cloud-samples-data");
   private static final Map<String, String> LABELS =
       ImmutableMap.of(
           "example-label1", "example-value1",


### PR DESCRIPTION
This makes it possible to run the tests in a VPC Service Controls perimeter where public buckets may be unreachable.