### PR TITLE
fix: handle specific exceptions

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
@@ -1,0 +1,20 @@
+package com.google.cloud.bigquery;
+
+import com.google.cloud.ExceptionHandler;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.BaseService;
+
+abstract class BigQueryBaseService<OptionsT extends ServiceOptions<?, OptionsT>> extends BaseService{
+
+
+    protected BigQueryBaseService(ServiceOptions options) {
+        super(options);
+    }
+
+    public static final ExceptionHandler BIGQUERY_EXCEPTION_HANDLER =
+            ExceptionHandler.newBuilder()
+                    .abortOn(RuntimeException.class)
+                    .retryOn(java.net.ConnectException.class)//retry on Connection Exception
+                    .addInterceptors(EXCEPTION_HANDLER_INTERCEPTOR)
+                    .build();
+}

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
@@ -4,8 +4,8 @@ import com.google.cloud.ExceptionHandler;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.BaseService;
 
-abstract class BigQueryBaseService<OptionsT extends ServiceOptions<?, OptionsT>> extends BaseService{
 
+abstract class BigQueryBaseService<OptionsT extends ServiceOptions<?, OptionsT>> extends BaseService{
 
     protected BigQueryBaseService(ServiceOptions options) {
         super(options);
@@ -15,6 +15,7 @@ abstract class BigQueryBaseService<OptionsT extends ServiceOptions<?, OptionsT>>
             ExceptionHandler.newBuilder()
                     .abortOn(RuntimeException.class)
                     .retryOn(java.net.ConnectException.class)//retry on Connection Exception
+                    .retryOn(java.net.UnknownHostException.class)//retry on UnknownHostException
                     .addInterceptors(EXCEPTION_HANDLER_INTERCEPTOR)
                     .build();
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigquery;
 
 import com.google.cloud.ExceptionHandler;

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
@@ -15,22 +15,22 @@
  */
 package com.google.cloud.bigquery;
 
+import com.google.cloud.BaseService;
 import com.google.cloud.ExceptionHandler;
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.BaseService;
 
+abstract class BigQueryBaseService<OptionsT extends ServiceOptions<?, OptionsT>>
+    extends BaseService {
 
-abstract class BigQueryBaseService<OptionsT extends ServiceOptions<?, OptionsT>> extends BaseService{
+  protected BigQueryBaseService(ServiceOptions options) {
+    super(options);
+  }
 
-    protected BigQueryBaseService(ServiceOptions options) {
-        super(options);
-    }
-
-    public static final ExceptionHandler BIGQUERY_EXCEPTION_HANDLER =
-            ExceptionHandler.newBuilder()
-                    .abortOn(RuntimeException.class)
-                    .retryOn(java.net.ConnectException.class)//retry on Connection Exception
-                    .retryOn(java.net.UnknownHostException.class)//retry on UnknownHostException
-                    .addInterceptors(EXCEPTION_HANDLER_INTERCEPTOR)
-                    .build();
+  public static final ExceptionHandler BIGQUERY_EXCEPTION_HANDLER =
+      ExceptionHandler.newBuilder()
+          .abortOn(RuntimeException.class)
+          .retryOn(java.net.ConnectException.class) // retry on Connection Exception
+          .retryOn(java.net.UnknownHostException.class) // retry on UnknownHostException
+          .addInterceptors(EXCEPTION_HANDLER_INTERCEPTOR)
+          .build();
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryBaseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -369,7 +369,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                   }
                 },
                 getOptions().getRetrySettings(),
-                    EXCEPTION_HANDLER,
+                EXCEPTION_HANDLER,
                 getOptions().getClock()));
       } catch (RetryHelper.RetryHelperException e) {
         throw BigQueryException.translateAndThrow(e);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.cloud.bigquery;
 
 import static com.google.cloud.RetryHelper.runWithRetries;
@@ -293,7 +292,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                 }
               },
               getOptions().getRetrySettings(),
-              EXCEPTION_HANDLER,
+                  EXCEPTION_HANDLER,
               getOptions().getClock()));
     } catch (RetryHelper.RetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
@@ -370,7 +369,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                   }
                 },
                 getOptions().getRetrySettings(),
-                    BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
+                    EXCEPTION_HANDLER,
                 getOptions().getClock()));
       } catch (RetryHelper.RetryHelperException e) {
         throw BigQueryException.translateAndThrow(e);
@@ -458,7 +457,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                 }
               },
               serviceOptions.getRetrySettings(),
-              EXCEPTION_HANDLER,
+              BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock());
       String cursor = result.x();
       return new PageImpl<>(

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -292,7 +292,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                 }
               },
               getOptions().getRetrySettings(),
-                  EXCEPTION_HANDLER,
+              EXCEPTION_HANDLER,
               getOptions().getClock()));
     } catch (RetryHelper.RetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1255,7 +1255,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                 }
               },
               getOptions().getRetrySettings(),
-              EXCEPTION_HANDLER,
+              BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock());
     } catch (RetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -370,7 +370,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                   }
                 },
                 getOptions().getRetrySettings(),
-                EXCEPTION_HANDLER,
+                    BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
                 getOptions().getClock()));
       } catch (RetryHelper.RetryHelperException e) {
         throw BigQueryException.translateAndThrow(e);


### PR DESCRIPTION
Added retry logic on `java.net.ConnectException` and `java.net.UnknownHostException` for `BigQueryImpl.listDatasets()` and `BigQueryImpl.queryRpc()` methods

Fixes # https://github.com/googleapis/java-bigquery/issues/1254 and https://github.com/googleapis/gax-java/issues/1301 ☕️
