### PR TITLE
feat: add Connection interface

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -69,12 +69,11 @@ integration)
       verify
     RETURN_CODE=$?
     ;;
-# TODO(mpeddada): un-comment below when graalvm tests are fixed for Apache Arrow
-#graalvm)
-#    # Run Unit and Integration Tests with Native Image
-#    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
-#    RETURN_CODE=$?
-#    ;;
+graalvm)
+    # Run Unit and Integration Tests with Native Image
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
+    RETURN_CODE=$?
+    ;;
 samples)
     SAMPLES_DIR=samples
     # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -69,11 +69,12 @@ integration)
       verify
     RETURN_CODE=$?
     ;;
-graalvm)
-    # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
-    RETURN_CODE=$?
-    ;;
+# TODO(mpeddada): un-comment below when graalvm tests are fixed for Apache Arrow
+#graalvm)
+#    # Run Unit and Integration Tests with Native Image
+#    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
+#    RETURN_CODE=$?
+#    ;;
 samples)
     SAMPLES_DIR=samples
     # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.

--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -67,13 +67,13 @@ function completenessCheck() {
   msg "Generating dependency list using original pom..."
   # Excluding commons-codec,commons-logging from the comparison as a temp fix
   # Explanation and issue filed in maven-dependency-plugin: https://issues.apache.org/jira/browse/MDEP-737
-  mvn dependency:list -f pom.xml -DexcludeArtifactIds=commons-codec,commons-logging -DincludeScope=runtime -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e s/\\s--\\smodule.*// >.org-list.txt
+  mvn dependency:list -f pom.xml -DexcludeArtifactIds=commons-codec,commons-logging,grpc-googleapis -DincludeScope=runtime -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e s/\\s--\\smodule.*// >.org-list.txt
 
   # Output dep list generated using the flattened pom (only 'compile' and 'runtime' scopes)
   msg "Generating dependency list using flattened pom..."
   # Excluding commons-codec,commons-logging from the comparison as a temp fix
   # Explanation and issue filed in maven-dependency-plugin: https://issues.apache.org/jira/browse/MDEP-737
-  mvn dependency:list -f .flattened-pom.xml -DexcludeArtifactIds=commons-codec,commons-logging -DincludeScope=runtime -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
+  mvn dependency:list -f .flattened-pom.xml -DexcludeArtifactIds=commons-codec,commons-logging,grpc-googleapis -DincludeScope=runtime -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
 
   # Compare two dependency lists
   msg "Comparing dependency lists..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### [2.10.10](https://github.com/googleapis/java-bigquery/compare/v2.10.9...v2.10.10) (2022-04-18)
+
+
+### Dependencies
+
+* update dependency com.google.cloud:google-cloud-bigtable to v2.6.2 ([#1990](https://github.com/googleapis/java-bigquery/issues/1990)) ([4c1cb4c](https://github.com/googleapis/java-bigquery/commit/4c1cb4c13214556b706f1ff8c50a46f881bf2724))
+* update dependency com.google.cloud:google-cloud-storage to v2.6.1 ([#1991](https://github.com/googleapis/java-bigquery/issues/1991)) ([e02bf31](https://github.com/googleapis/java-bigquery/commit/e02bf315737dba50741c1346af8bde6871cb857a))
+
 ### [2.10.9](https://github.com/googleapis/java-bigquery/compare/v2.10.8...v2.10.9) (2022-04-16)
 
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>google-cloud-bigquery-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>2.10.10-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+    <version>2.10.11-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
   </parent>
 
   <properties>

--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -50,7 +50,8 @@ public class ConnImplBenchmark {
   private ConnectionSettings connectionSettingsReadAPIEnabled, connectionSettingsReadAPIDisabled;
   private long numBuffRows = 100000L;
   private final String DATASET = "bigquery_test_dataset";
-  private final String QUERY = "SELECT * FROM tlc_yellow_trips_2017_stephwang LIMIT %s";
+  private final String QUERY =
+      "SELECT * FROM bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2017 LIMIT %s";
 
   @Setup
   public void setUp() throws IOException {

--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -52,6 +52,8 @@ public class ConnImplBenchmark {
   private final String DATASET = "bigquery_test_dataset";
   private final String QUERY =
       "SELECT * FROM bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2017 LIMIT %s";
+  public static final long NUM_PAGE_ROW_CNT_RATIO = 10;
+  public static final long NUM_MIN_RESULT_SIZE = 200000;
 
   @Setup
   public void setUp() throws IOException {
@@ -60,8 +62,8 @@ public class ConnImplBenchmark {
 
     clientConnectionConfiguration =
         ReadClientConnectionConfiguration.newBuilder()
-            .setTotalToPageRowCountRatio(10L)
-            .setMinResultSize(200000L)
+            .setTotalToPageRowCountRatio(NUM_PAGE_ROW_CNT_RATIO)
+            .setMinResultSize(NUM_MIN_RESULT_SIZE)
             .setBufferSize(numBuffRows)
             .build();
 

--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -49,7 +49,7 @@ public class ConnImplBenchmark {
 
   private ConnectionSettings connectionSettingsReadAPIEnabled, connectionSettingsReadAPIDisabled;
   private long numBuffRows = 100000L;
-  private final String DATASET = "bigquery_test_dataset";
+  private final String DATASET = "new_york_taxi_trips";
   private final String QUERY =
       "SELECT * FROM bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2017 LIMIT %s";
   public static final long NUM_PAGE_ROW_CNT_RATIO =

--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -52,8 +52,10 @@ public class ConnImplBenchmark {
   private final String DATASET = "bigquery_test_dataset";
   private final String QUERY =
       "SELECT * FROM bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2017 LIMIT %s";
-  public static final long NUM_PAGE_ROW_CNT_RATIO = 10;
-  public static final long NUM_MIN_RESULT_SIZE = 200000;
+  public static final long NUM_PAGE_ROW_CNT_RATIO =
+      10; // ratio of [records in the current page :: total rows] to be met to use read API
+  public static final long NUM_MIN_RESULT_SIZE =
+      200000; // min number of records to use to ReadAPI with
 
   @Setup
   public void setUp() throws IOException {

--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -39,7 +39,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @Fork(value = 1)
 @BenchmarkMode(Mode.AverageTime)
-@Warmup(iterations = 0)
+@Warmup(iterations = 1)
 @Measurement(iterations = 3)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -102,7 +102,7 @@ public class ConnImplBenchmark {
     } catch (Exception e) {
       e.printStackTrace();
     } finally {
-      connectionReadAPIEnabled.cancel(); // IMP to kill the bg workers
+      connectionReadAPIEnabled.close(); // IMP to kill the bg workers
     }
     blackhole.consume(hash);
   }
@@ -122,7 +122,7 @@ public class ConnImplBenchmark {
     } catch (Exception e) {
       e.printStackTrace();
     } finally {
-      connectionReadAPIDisabled.cancel(); // IMP to kill the bg workers
+      connectionReadAPIDisabled.close(); // IMP to kill the bg workers
     }
     blackhole.consume(hash);
   }

--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -20,11 +20,11 @@
   <difference>
     <differenceType>7012</differenceType>
     <className>com/google/cloud/bigquery/spi/v2/BigQueryRpc</className>
-    <method>com.google.api.services.bigquery.model.GetQueryResultsResponse getQueryResultsWithRowLimit(java.lang.String, java.lang.String, java.lang.String, java.lang.Long)</method>
+    <method>com.google.api.services.bigquery.model.GetQueryResultsResponse getQueryResultsWithRowLimit(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer)</method>
   </difference>
   <difference>
     <differenceType>7012</differenceType>
     <className>com/google/cloud/bigquery/spi/v2/BigQueryRpc</className>
-    <method>com.google.api.services.bigquery.model.TableDataList listTableDataWithRowLimit(java.lang.String, java.lang.String, java.lang.String, java.lang.Long, java.lang.String)</method>
+    <method>com.google.api.services.bigquery.model.TableDataList listTableDataWithRowLimit(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer, java.lang.String)</method>
   </difference>
 </differences>

--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -9,6 +9,11 @@
   </difference>
   <difference>
     <differenceType>7012</differenceType>
+    <className>com/google/cloud/bigquery/BigQuery</className>
+    <method>com.google.cloud.bigquery.Connection createConnection()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
     <className>com/google/cloud/bigquery/spi/v2/BigQueryRpc</className>
     <method>com.google.api.services.bigquery.model.Job createJobForQuery(com.google.api.services.bigquery.model.Job)</method>
   </difference>

--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-bigquery</artifactId>
-  <version>2.10.10-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+  <version>2.10.11-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
   <packaging>jar</packaging>
   <name>BigQuery</name>
   <url>https://github.com/googleapis/java-bigquery</url>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-bigquery-parent</artifactId>
-    <version>2.10.10-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+    <version>2.10.11-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-bigquery</site.installationModule>

--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>checker-compat-qual</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Lists;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * An interface for Google Cloud BigQuery.
@@ -782,10 +783,29 @@ public interface BigQuery extends Service<BigQueryOptions> {
    * </pre>
    *
    * @throws BigQueryException upon failure
-   * @param connectionSettings or null for default settings
+   * @param connectionSettings
    */
   @BetaApi
-  Connection createConnection(ConnectionSettings connectionSettings);
+  Connection createConnection(@NonNull ConnectionSettings connectionSettings);
+
+  /**
+   * Creates a new BigQuery query connection used for executing queries (not the same as BigQuery
+   * connection properties). It uses the BigQuery Storage Read API for high throughput queries by
+   * default. This overloaded method creates a default ConnectionSettings.
+   *
+   * <p>Example of creating a query connection.
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *       Connection connection = bigquery.createConnection();
+   * }
+   * </pre>
+   *
+   * @throws BigQueryException upon failure
+   */
+  @BetaApi
+  Connection createConnection();
 
   /**
    * Returns the requested dataset or {@code null} if not found.

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -791,7 +791,9 @@ public interface BigQuery extends Service<BigQueryOptions> {
   /**
    * Creates a new BigQuery query connection used for executing queries (not the same as BigQuery
    * connection properties). It uses the BigQuery Storage Read API for high throughput queries by
-   * default. This overloaded method creates a default ConnectionSettings.
+   * default. This overloaded method creates a Connection with default ConnectionSettings for query
+   * execution where default values are set for numBufferedRows (20000), useReadApi (true),
+   * useLegacySql (false).
    *
    * <p>Example of creating a query connection.
    *

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -762,7 +762,8 @@ public interface BigQuery extends Service<BigQueryOptions> {
 
   /**
    * Creates a new BigQuery query connection used for executing queries (not the same as BigQuery
-   * connection properties).
+   * connection properties). It uses the BigQuery Storage Read API for high throughput queries by
+   * default.
    *
    * <p>Example of creating a query connection.
    *
@@ -780,6 +781,7 @@ public interface BigQuery extends Service<BigQueryOptions> {
    * </pre>
    *
    * @throws BigQueryException upon failure
+   * @param connectionSettings or null for default settings
    */
   Connection createConnection(ConnectionSettings connectionSettings);
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.FieldSelector;
@@ -783,6 +784,7 @@ public interface BigQuery extends Service<BigQueryOptions> {
    * @throws BigQueryException upon failure
    * @param connectionSettings or null for default settings
    */
+  @BetaApi
   Connection createConnection(ConnectionSettings connectionSettings);
 
   /**

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResult.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResult.java
@@ -32,4 +32,8 @@ public interface BigQueryDryRunResult {
    */
   @BetaApi
   List<Parameter> getQueryParameters() throws BigQuerySQLException;
+
+  /** Returns some processing statistics */
+  @BetaApi
+  BigQueryResultStats getStatistics() throws BigQuerySQLException;
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResult.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResult.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.bigquery;
 
-import com.google.api.services.bigquery.model.QueryParameter;
 import java.util.List;
 
 public interface BigQueryDryRunResult {
@@ -25,5 +24,5 @@ public interface BigQueryDryRunResult {
   Schema getSchema() throws BigQuerySQLException;
 
   /** Returns query parameters for standard SQL queries */
-  List<QueryParameter> getQueryParameters() throws BigQuerySQLException;
+  List<Parameter> getQueryParameters() throws BigQuerySQLException;
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResult.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResult.java
@@ -16,11 +16,13 @@
 
 package com.google.cloud.bigquery;
 
+import com.google.api.core.BetaApi;
 import java.util.List;
 
 public interface BigQueryDryRunResult {
 
   /** Returns the schema of the results. Null if the schema is not supplied. */
+  @BetaApi
   Schema getSchema() throws BigQuerySQLException;
 
   /**
@@ -28,5 +30,6 @@ public interface BigQueryDryRunResult {
    * the dry run job. See more information:
    * https://developers.google.com/resources/api-libraries/documentation/bigquery/v2/java/latest/com/google/api/services/bigquery/model/JobStatistics2.html#getUndeclaredQueryParameters--
    */
+  @BetaApi
   List<Parameter> getQueryParameters() throws BigQuerySQLException;
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResultImpl.java
@@ -16,15 +16,14 @@
 
 package com.google.cloud.bigquery;
 
-import com.google.api.services.bigquery.model.QueryParameter;
 import java.util.List;
 
 public class BigQueryDryRunResultImpl implements BigQueryDryRunResult {
   private Schema schema;
-  private List<QueryParameter> queryParameters;
+  private List<Parameter> queryParameters;
 
   BigQueryDryRunResultImpl(
-      Schema schema, List<QueryParameter> queryParameters) { // Package-Private access
+      Schema schema, List<Parameter> queryParameters) { // Package-Private access
     this.schema = schema;
     this.queryParameters = queryParameters;
   }
@@ -35,7 +34,7 @@ public class BigQueryDryRunResultImpl implements BigQueryDryRunResult {
   }
 
   @Override
-  public List<QueryParameter> getQueryParameters() throws BigQuerySQLException {
+  public List<Parameter> getQueryParameters() throws BigQuerySQLException {
     return queryParameters;
   }
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryDryRunResultImpl.java
@@ -21,11 +21,15 @@ import java.util.List;
 public class BigQueryDryRunResultImpl implements BigQueryDryRunResult {
   private Schema schema;
   private List<Parameter> queryParameters;
+  private BigQueryResultStats stats;
 
   BigQueryDryRunResultImpl(
-      Schema schema, List<Parameter> queryParameters) { // Package-Private access
+      Schema schema,
+      List<Parameter> queryParameters,
+      BigQueryResultStats stats) { // Package-Private access
     this.schema = schema;
     this.queryParameters = queryParameters;
+    this.stats = stats;
   }
 
   @Override
@@ -36,5 +40,10 @@ public class BigQueryDryRunResultImpl implements BigQueryDryRunResult {
   @Override
   public List<Parameter> getQueryParameters() throws BigQuerySQLException {
     return queryParameters;
+  }
+
+  @Override
+  public BigQueryResultStats getStatistics() throws BigQuerySQLException {
+    return stats;
   }
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -21,6 +21,7 @@ import static com.google.cloud.bigquery.PolicyHelper.convertToApiPolicy;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.paging.Page;
 import com.google.api.services.bigquery.model.ErrorProto;
@@ -54,6 +55,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuery {
 
@@ -352,9 +354,18 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
   }
 
   @Override
-  public Connection createConnection(ConnectionSettings connectionSettings)
+  @BetaApi
+  public Connection createConnection(@NonNull ConnectionSettings connectionSettings)
       throws BigQueryException {
     return new ConnectionImpl(connectionSettings, getOptions(), bigQueryRpc, DEFAULT_RETRY_CONFIG);
+  }
+
+  @Override
+  @BetaApi
+  public Connection createConnection() throws BigQueryException {
+    ConnectionSettings defaultConnectionSettings = ConnectionSettings.newBuilder().build();
+    return new ConnectionImpl(
+        defaultConnectionSettings, getOptions(), bigQueryRpc, DEFAULT_RETRY_CONFIG);
   }
 
   @InternalApi("visible for testing")

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
@@ -245,6 +245,10 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         }
         if (curVal instanceof Text) { // parse from text to int
           return Integer.parseInt(((Text) curVal).toString());
+        } else if (curVal
+            instanceof
+            Long) { // incase getInt is called for a Long value. Loss of precision might occur
+          return ((Long) curVal).intValue();
         }
         return ((BigDecimal) curVal).intValue();
       }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
@@ -144,7 +144,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null ? null : fieldValue.getValue();
+        return (fieldValue == null || fieldValue.getValue() == null) ? null : fieldValue.getValue();
       } else { // Data received from Read API (Arrow)
         Row curRow = (Row) cursor;
         if (!curRow.hasField(fieldName)) {
@@ -160,7 +160,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         return null;
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null ? null : fieldValue.getValue();
+        return (fieldValue == null || fieldValue.getValue() == null) ? null : fieldValue.getValue();
       } else { // Data received from Read API (Arrow)
         return getObject(schemaFieldList.get(columnIndex).getName());
       }
@@ -175,7 +175,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        if (fieldValue.getValue() == null) {
+        if ((fieldValue == null || fieldValue.getValue() == null)) {
           return null;
         } else if (fieldValue
             .getAttribute()
@@ -211,7 +211,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         return null;
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null ? null : fieldValue.getStringValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? null
+            : fieldValue.getStringValue();
       } else { // Data received from Read API (Arrow)
         return getString(schemaFieldList.get(columnIndex).getName());
       }
@@ -227,7 +229,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         // java.sql.ResultSet definition
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null ? 0 : fieldValue.getNumericValue().intValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? 0
+            : fieldValue.getNumericValue().intValue();
       } else { // Data received from Read API (Arrow)
 
         Row curRow = (Row) cursor;
@@ -252,7 +256,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         // java.sql.ResultSet definition
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null ? 0 : fieldValue.getNumericValue().intValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? 0
+            : fieldValue.getNumericValue().intValue();
       } else { // Data received from Read API (Arrow)
         return getInt(schemaFieldList.get(columnIndex).getName());
       }
@@ -267,7 +273,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null ? 0L : fieldValue.getNumericValue().longValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? 0L
+            : fieldValue.getNumericValue().longValue();
       } else { // Data received from Read API (Arrow)
         Row curRow = (Row) cursor;
         if (!curRow.hasField(fieldName)) {
@@ -291,7 +299,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         // java.sql.ResultSet definition
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null ? 0L : fieldValue.getNumericValue().longValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? 0L
+            : fieldValue.getNumericValue().longValue();
       } else { // Data received from Read API (Arrow)
         return getInt(schemaFieldList.get(columnIndex).getName());
       }
@@ -306,7 +316,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null ? 0d : fieldValue.getNumericValue().doubleValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? 0d
+            : fieldValue.getNumericValue().doubleValue();
       } else { // Data received from Read API (Arrow)
         Row curRow = (Row) cursor;
         if (!curRow.hasField(fieldName)) {
@@ -324,7 +336,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         // java.sql.ResultSet definition
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null ? 0d : fieldValue.getNumericValue().doubleValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? 0d
+            : fieldValue.getNumericValue().doubleValue();
       } else { // Data received from Read API (Arrow)
         return getDouble(schemaFieldList.get(columnIndex).getName());
       }
@@ -339,7 +353,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null
+        return (fieldValue == null || fieldValue.getValue() == null)
             ? null
             : BigDecimal.valueOf(fieldValue.getNumericValue().doubleValue());
       } else { // Data received from Read API (Arrow)
@@ -353,7 +367,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null
+        return (fieldValue == null || fieldValue.getValue() == null)
             ? null
             : BigDecimal.valueOf(fieldValue.getNumericValue().doubleValue());
       } else { // Data received from Read API (Arrow)
@@ -402,7 +416,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null ? null : fieldValue.getBytesValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? null
+            : fieldValue.getBytesValue();
       } else { // Data received from Read API (Arrow)
         Row curRow = (Row) cursor;
         if (!curRow.hasField(fieldName)) {
@@ -419,7 +435,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         return null; //  if the value is SQL NULL, the value returned is null
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null ? null : fieldValue.getBytesValue();
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? null
+            : fieldValue.getBytesValue();
       } else { // Data received from Read API (Arrow)
         return getBytes(schemaFieldList.get(columnIndex).getName());
       }
@@ -434,7 +452,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         return null; //  if the value is SQL NULL, the value returned is null
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null
+        return (fieldValue == null || fieldValue.getValue() == null)
             ? null
             : new Timestamp(
                 fieldValue.getTimestampValue()
@@ -458,7 +476,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null
+        return (fieldValue == null || fieldValue.getValue() == null)
             ? null
             : new Timestamp(
                 fieldValue.getTimestampValue()
@@ -544,7 +562,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
-        return fieldValue.getValue() == null ? null : Date.valueOf(fieldValue.getStringValue());
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? null
+            : Date.valueOf(fieldValue.getStringValue());
       } else { // Data received from Read API (Arrow)
         Row curRow = (Row) cursor;
         if (!curRow.hasField(fieldName)) {
@@ -571,7 +591,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
-        return fieldValue.getValue() == null ? null : Date.valueOf(fieldValue.getStringValue());
+        return (fieldValue == null || fieldValue.getValue() == null)
+            ? null
+            : Date.valueOf(fieldValue.getStringValue());
       } else { // Data received from Read API (Arrow)
         return getDate(schemaFieldList.get(columnIndex).getName());
       }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
@@ -120,6 +120,9 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
             cursor = null;
             return false;
           }
+          return true;
+        } else if (cursor instanceof FieldValueList) { // cursor is advanced, we can return true now
+          return true;
         } else { // this case should never occur as the cursor will either be a Row of EoS
           throw new BigQuerySQLException("Could not process the current row");
         }
@@ -127,8 +130,6 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException(
             "Error occurred while advancing the cursor. This could happen when connection is closed while we call the next method");
       }
-
-      return true;
     }
 
     private boolean isEndOfStream(T cursor) {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
@@ -284,10 +284,8 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         Object curVal = curRow.get(fieldName);
         if (curVal == null) {
           return 0L;
-        } else if (curVal instanceof Long) {
-          return ((Long) curVal).longValue();
-        } else {
-          return ((BigDecimal) curVal).longValue();
+        } else { // value will be Long or BigDecimal, but are Number
+          return ((Number) curVal).longValue();
         }
       }
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
@@ -34,6 +34,9 @@ import org.apache.arrow.vector.util.Text;
 
 public class BigQueryResultImpl<T> implements BigQueryResult<T> {
 
+  private static final String NULL_CURSOR_MSG =
+      "Error occurred while reading the cursor. This could happen if getters are called after we are done reading all the records";
+
   // This class represents a row of records, the columns are represented as a map
   // (columnName:columnValue pair)
   static class Row {
@@ -121,7 +124,8 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
           throw new BigQuerySQLException("Could not process the current row");
         }
       } catch (InterruptedException e) {
-        throw new SQLException("Error occurred while reading buffer");
+        throw new SQLException(
+            "Error occurred while advancing the cursor. This could happen when connection is closed while we call the next method");
       }
 
       return true;
@@ -137,7 +141,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return null;
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         return fieldValue.getValue() == null ? null : fieldValue.getValue();
@@ -168,7 +172,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return null;
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         if (fieldValue.getValue() == null) {
@@ -260,8 +264,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return 0L; // the column value; if the value is SQL NULL, the value returned is 0 as per
-        // java.sql.ResultSet definition
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         return fieldValue.getValue() == null ? 0L : fieldValue.getNumericValue().longValue();
@@ -300,8 +303,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return 0d; // the column value; if the value is SQL NULL, the value returned is 0 as per
-        // java.sql.ResultSet definition
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         return fieldValue.getValue() == null ? 0d : fieldValue.getNumericValue().doubleValue();
@@ -334,9 +336,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return null; // the column value (full precision); if the value is SQL NULL, the value
-        // returned is null in the Java programming language. as per
-        // java.sql.ResultSet definition
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         return fieldValue.getValue() == null
@@ -350,9 +350,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
       if (cursor == null) {
-        return null; // the column value (full precision); if the value is SQL NULL, the value
-        // returned is null in the Java programming language. as per
-        // java.sql.ResultSet definition
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
         return fieldValue.getValue() == null
@@ -369,7 +367,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return false; //  if the value is SQL NULL, the value returned is false
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         return fieldValue.getValue() != null && fieldValue.getBooleanValue();
@@ -386,7 +384,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
       if (cursor == null) {
-        return false; //  if the value is SQL NULL, the value returned is false
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
         return fieldValue.getValue() != null && fieldValue.getBooleanValue();
@@ -401,7 +399,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return null; //  if the value is SQL NULL, the value returned is null
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         return fieldValue.getValue() == null ? null : fieldValue.getBytesValue();
@@ -430,7 +428,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
     @Override
     public Timestamp getTimestamp(String fieldName) throws SQLException {
       if (fieldName == null) {
-        throw new SQLException("fieldName can't be null");
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       }
       if (cursor == null) {
         return null; //  if the value is SQL NULL, the value returned is null
@@ -457,7 +455,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
     @Override
     public Timestamp getTimestamp(int columnIndex) throws SQLException {
       if (cursor == null) {
-        return null; //  if the value is SQL NULL, the value returned is null
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
         return fieldValue.getValue() == null
@@ -474,7 +472,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
     @Override
     public Time getTime(String fieldName) throws SQLException {
       if (fieldName == null) {
-        throw new SQLException("fieldName can't be null");
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       }
       if (cursor == null) {
         return null; //  if the value is SQL NULL, the value returned is null
@@ -504,7 +502,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
     @Override
     public Time getTime(int columnIndex) throws SQLException {
       if (cursor == null) {
-        return null; //  if the value is SQL NULL, the value returned is null
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
         return getTimeFromFieldVal(fieldValue);
@@ -543,7 +541,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
         throw new SQLException("fieldName can't be null");
       }
       if (cursor == null) {
-        return null; //  if the value is SQL NULL, the value returned is null
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(fieldName);
         return fieldValue.getValue() == null ? null : Date.valueOf(fieldValue.getStringValue());
@@ -570,7 +568,7 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
     @Override
     public Date getDate(int columnIndex) throws SQLException {
       if (cursor == null) {
-        return null; //  if the value is SQL NULL, the value returned is null
+        throw new BigQuerySQLException(NULL_CURSOR_MSG);
       } else if (cursor instanceof FieldValueList) {
         FieldValue fieldValue = ((FieldValueList) cursor).get(columnIndex);
         return fieldValue.getValue() == null ? null : Date.valueOf(fieldValue.getStringValue());

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultSetImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultSetImpl.java
@@ -29,6 +29,7 @@ import java.time.ZoneId;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.Text;
 
@@ -525,9 +526,9 @@ public class BigQueryResultSetImpl<T> implements BigQueryResultSet<T> {
         } else {
           Integer dateInt = (Integer) dateObj;
           long dateInMillis =
-              Long.valueOf(dateInt)
-                  * (24 * 60 * 60
-                      * 1000); // For example int 18993 represents 2022-01-01, converting time to
+              TimeUnit.DAYS.toMillis(
+                  Long.valueOf(
+                      dateInt)); // For example int 18993 represents 2022-01-01, converting time to
           // milli seconds
           return new Date(dateInMillis);
         }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultSetImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultSetImpl.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.Text;
 
-// TODO: This implementation deals with the JSON response. We can have respective implementations
 public class BigQueryResultSetImpl<T> implements BigQueryResultSet<T> {
 
   private final Schema schema;

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultStats.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultStats.java
@@ -16,13 +16,16 @@
 
 package com.google.cloud.bigquery;
 
+import com.google.api.core.BetaApi;
 import com.google.cloud.bigquery.JobStatistics.SessionInfo;
 
 public interface BigQueryResultStats {
 
   /** Returns detailed statistics for DML statements. */
+  @BetaApi
   DmlStats getDmlStats();
 
   /** Returns SessionInfo contains information about the session if this job is part of one. */
+  @BetaApi
   SessionInfo getSessionInfo();
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultStats.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultStats.java
@@ -17,15 +17,20 @@
 package com.google.cloud.bigquery;
 
 import com.google.api.core.BetaApi;
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics;
 import com.google.cloud.bigquery.JobStatistics.SessionInfo;
 
 public interface BigQueryResultStats {
 
-  /** Returns detailed statistics for DML statements. */
+  /** Returns query statistics of a query job */
   @BetaApi
-  DmlStats getDmlStats();
+  QueryStatistics getQueryStatistics();
 
-  /** Returns SessionInfo contains information about the session if this job is part of one. */
+  /**
+   * Returns SessionInfo contains information about the session if this job is part of one.
+   * JobStatistics2 model class does not allow setSessionInfo so this cannot be set as part of
+   * QueryStatistics when we use jobs.query API.
+   */
   @BetaApi
   SessionInfo getSessionInfo();
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultStatsImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultStatsImpl.java
@@ -16,21 +16,22 @@
 
 package com.google.cloud.bigquery;
 
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics;
 import com.google.cloud.bigquery.JobStatistics.SessionInfo;
 
 public class BigQueryResultStatsImpl implements BigQueryResultStats {
 
-  private final DmlStats dmlStats;
+  private final QueryStatistics queryStatistics;
   private final SessionInfo sessionInfo;
 
-  public BigQueryResultStatsImpl(DmlStats dmlStats, SessionInfo sessionInfo) {
-    this.dmlStats = dmlStats;
+  public BigQueryResultStatsImpl(QueryStatistics queryStatistics, SessionInfo sessionInfo) {
+    this.queryStatistics = queryStatistics;
     this.sessionInfo = sessionInfo;
   }
 
   @Override
-  public DmlStats getDmlStats() {
-    return dmlStats;
+  public QueryStatistics getQueryStatistics() {
+    return queryStatistics;
   }
 
   @Override

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuerySQLException.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuerySQLException.java
@@ -34,6 +34,12 @@ public final class BigQuerySQLException extends SQLException {
     this.errors = null;
   }
 
+  public BigQuerySQLException(
+      String msg) { // overloaded constructor with just message as an argument
+    super(msg);
+    this.errors = null;
+  }
+
   public BigQuerySQLException(List<BigQueryError> errors) {
     this.errors = errors;
   }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
@@ -28,7 +28,7 @@ public interface Connection {
 
   /** Sends a query cancel request. This call will return immediately */
   @BetaApi
-  Boolean cancel() throws BigQuerySQLException;
+  Boolean close() throws BigQuerySQLException;
 
   /**
    * Execute a query dry run that does not return any BigQueryResultSet // TODO: explain more about

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
@@ -28,7 +28,7 @@ public interface Connection {
 
   /** Sends a query cancel request. This call will return immediately */
   @BetaApi
-  Boolean close() throws BigQuerySQLException;
+  boolean close() throws BigQuerySQLException;
 
   /**
    * Execute a query dry run that does not return any BigQueryResult // TODO: explain more about

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
@@ -31,8 +31,8 @@ public interface Connection {
   boolean close() throws BigQuerySQLException;
 
   /**
-   * Execute a query dry run that does not return any BigQueryResult // TODO: explain more about
-   * what this method does here
+   * Execute a query dry run that returns information on the schema and query parameters of the
+   * query results.
    *
    * @param sql typically a static SQL SELECT statement
    * @exception BigQuerySQLException if a database access error occurs
@@ -41,30 +41,26 @@ public interface Connection {
   BigQueryDryRunResult dryRun(String sql) throws BigQuerySQLException;
 
   /**
-   * Execute a SQL statement that returns a single ResultSet
+   * Execute a SQL statement that returns a single ResultSet.
    *
    * <p>Example of running a query.
    *
    * <pre>
    * {
    *   &#64;code
-   *   // ConnectionSettings connectionSettings =
-   *   //     ConnectionSettings.newBuilder()
-   *   //         .setRequestTimeout(10L)
-   *   //         .setMaxResults(100L)
-   *   //         .setUseQueryCache(true)
-   *   //         .build();
-   *   // Connection connection = bigquery.createConnection(connectionSettings);
+   *   ConnectionSettings connectionSettings =
+   *        ConnectionSettings.newBuilder()
+   *            .setRequestTimeout(10L)
+   *            .setMaxResults(100L)
+   *            .setUseQueryCache(true)
+   *            .build();
+   *   Connection connection = bigquery.createConnection(connectionSettings);
    *   String selectQuery = "SELECT corpus FROM `bigquery-public-data.samples.shakespeare` GROUP BY corpus;";
-   *   try (BigQueryResult bqResultSet = connection.executeSelect(selectQuery)) {
-   *       ResultSet rs = bqResultSet.getResultSet();
-   *       while (rs.next()) {
-   *           System.out.printf("%s,", rs.getString("corpus"));
-   *       }
-   *   } catch (BigQuerySQLException ex) {
-   *       // handle exception
+   *   BigQueryResult bqResultSet = connection.executeSelect(selectQuery)
+   *   ResultSet rs = bqResultSet.getResultSet();
+   *   while (rs.next()) {
+   *       System.out.printf("%s,", rs.getString("corpus"));
    *   }
-   * }
    * </pre>
    *
    * @param sql a static SQL SELECT statement
@@ -80,9 +76,9 @@ public interface Connection {
    * @param sql SQL SELECT query
    * @param parameters named or positional parameters. The set of query parameters must either be
    *     all positional or all named parameters.
-   * @param labels the labels associated with this query. You can use these to organize and group
-   *     your query jobs. Label keys and values can be no longer than 63 characters, can only
-   *     contain lowercase letters, numeric characters, underscores and dashes. International
+   * @param labels (optional) the labels associated with this query. You can use these to organize
+   *     and group your query jobs. Label keys and values can be no longer than 63 characters, can
+   *     only contain lowercase letters, numeric characters, underscores and dashes. International
    *     characters are allowed. Label values are optional and Label is a Varargs. You should pass
    *     all the Labels in a single Map .Label keys must start with a letter and each label in the
    *     list must have a different key.

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Connection.java
@@ -75,22 +75,22 @@ public interface Connection {
   BigQueryResultSet executeSelect(String sql) throws BigQuerySQLException;
 
   /**
-   * Execute a SQL statement with query parameters that returns a single ResultSet
+   * This method executes a SQL SELECT query
    *
-   * @param sql typically a static SQL SELECT statement
+   * @param sql SQL SELECT query
    * @param parameters named or positional parameters. The set of query parameters must either be
-   *     all positional or all named parameters. Named parameters are denoted using an @ prefix,
-   *     e.g. @myParam for a parameter named "myParam".
+   *     all positional or all named parameters.
    * @param labels the labels associated with this query. You can use these to organize and group
    *     your query jobs. Label keys and values can be no longer than 63 characters, can only
    *     contain lowercase letters, numeric characters, underscores and dashes. International
-   *     characters are allowed. Label values are optional. Label keys must start with a letter and
-   *     each label in the list must have a different key.
-   * @return a ResultSet that contains the data produced by the query
-   * @exception BigQuerySQLException if a database access error occurs
+   *     characters are allowed. Label values are optional and Label is a Varargs. You should pass
+   *     all the Labels in a single Map .Label keys must start with a letter and each label in the
+   *     list must have a different key.
+   * @return BigQueryResultSet containing the output of the query
+   * @throws BigQuerySQLException
    */
   @BetaApi
   BigQueryResultSet executeSelect(
-      String sql, List<Parameter> parameters, Map<String, String> labels)
+      String sql, List<Parameter> parameters, Map<String, String>... labels)
       throws BigQuerySQLException;
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -987,45 +987,43 @@ class ConnectionImpl implements Connection {
     QueryRequest content = new QueryRequest();
     String requestId = UUID.randomUUID().toString();
 
-    if (connectionSettings != null) {
-      if (connectionSettings.getConnectionProperties() != null) {
-        content.setConnectionProperties(
-            connectionSettings.getConnectionProperties().stream()
-                .map(ConnectionProperty.TO_PB_FUNCTION)
-                .collect(Collectors.toList()));
+    if (connectionSettings.getConnectionProperties() != null) {
+      content.setConnectionProperties(
+          connectionSettings.getConnectionProperties().stream()
+              .map(ConnectionProperty.TO_PB_FUNCTION)
+              .collect(Collectors.toList()));
+    }
+    if (connectionSettings.getDefaultDataset() != null) {
+      content.setDefaultDataset(connectionSettings.getDefaultDataset().toPb());
+    }
+    if (connectionSettings.getMaximumBytesBilled() != null) {
+      content.setMaximumBytesBilled(connectionSettings.getMaximumBytesBilled());
+    }
+    if (connectionSettings.getMaxResults() != null) {
+      content.setMaxResults(connectionSettings.getMaxResults());
+    }
+    if (queryParameters != null) {
+      // content.setQueryParameters(queryParameters);
+      if (queryParameters.get(0).getName() == null) {
+        // If query parameter name is unset, then assume mode is positional
+        content.setParameterMode("POSITIONAL");
+        // pass query parameters
+        List<QueryParameter> queryParametersPb =
+            Lists.transform(queryParameters, POSITIONAL_PARAMETER_TO_PB_FUNCTION);
+        content.setQueryParameters(queryParametersPb);
+      } else {
+        content.setParameterMode("NAMED");
+        // pass query parameters
+        List<QueryParameter> queryParametersPb =
+            Lists.transform(queryParameters, NAMED_PARAMETER_TO_PB_FUNCTION);
+        content.setQueryParameters(queryParametersPb);
       }
-      if (connectionSettings.getDefaultDataset() != null) {
-        content.setDefaultDataset(connectionSettings.getDefaultDataset().toPb());
-      }
-      if (connectionSettings.getMaximumBytesBilled() != null) {
-        content.setMaximumBytesBilled(connectionSettings.getMaximumBytesBilled());
-      }
-      if (connectionSettings.getMaxResults() != null) {
-        content.setMaxResults(connectionSettings.getMaxResults());
-      }
-      if (queryParameters != null) {
-        // content.setQueryParameters(queryParameters);
-        if (queryParameters.get(0).getName() == null) {
-          // If query parameter name is unset, then assume mode is positional
-          content.setParameterMode("POSITIONAL");
-          // pass query parameters
-          List<QueryParameter> queryParametersPb =
-              Lists.transform(queryParameters, POSITIONAL_PARAMETER_TO_PB_FUNCTION);
-          content.setQueryParameters(queryParametersPb);
-        } else {
-          content.setParameterMode("NAMED");
-          // pass query parameters
-          List<QueryParameter> queryParametersPb =
-              Lists.transform(queryParameters, NAMED_PARAMETER_TO_PB_FUNCTION);
-          content.setQueryParameters(queryParametersPb);
-        }
-      }
-      if (connectionSettings.getCreateSession() != null) {
-        content.setCreateSession(connectionSettings.getCreateSession());
-      }
-      if (labels != null) {
-        content.setLabels(labels);
-      }
+    }
+    if (connectionSettings.getCreateSession() != null) {
+      content.setCreateSession(connectionSettings.getCreateSession());
+    }
+    if (labels != null) {
+      content.setLabels(labels);
     }
     content.setQuery(sql);
     content.setRequestId(requestId);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -112,7 +112,7 @@ class ConnectionImpl implements Connection {
    */
   @BetaApi
   @Override
-  public synchronized Boolean cancel() throws BigQuerySQLException {
+  public synchronized Boolean close() throws BigQuerySQLException {
     queryTaskExecutor.shutdownNow();
     return queryTaskExecutor.isShutdown();
   }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -44,7 +44,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -533,10 +532,7 @@ class ConnectionImpl implements Connection {
           } catch (InterruptedException e) {
             throw new BigQueryException(0, e.getMessage(), e);
           } finally {
-            MoreExecutors.shutdownAndAwaitTermination(
-                queryTaskExecutor,
-                EXECUTOR_TIMEOUT_SEC,
-                TimeUnit.SECONDS); // Shutdown the thread pool
+            queryTaskExecutor.shutdownNow(); // Shutdown the thread pool
           }
         };
 
@@ -730,8 +726,7 @@ class ConnectionImpl implements Connection {
           ;
 
       ReadSession readSession = bqReadClient.createReadSession(builder.build());
-      BlockingQueue<Tuple<Map<String, Object>, Boolean>> buffer =
-          new LinkedBlockingDeque<>(bufferSize);
+      BlockingQueue<BigQueryResultImpl.Row> buffer = new LinkedBlockingDeque<>(bufferSize);
       Map<String, Integer> arrowNameToIndex = new HashMap<>();
       // deserialize and populate the buffer async, so that the client isn't blocked
       processArrowStreamAsync(
@@ -741,8 +736,7 @@ class ConnectionImpl implements Connection {
           schema);
 
       logger.log(Level.INFO, "\n Using BigQuery Read API");
-      return new BigQueryResultImpl<Tuple<Map<String, Object>, Boolean>>(
-          schema, totalRows, buffer, stats);
+      return new BigQueryResultImpl<BigQueryResultImpl.Row>(schema, totalRows, buffer, stats);
 
     } catch (IOException e) {
       throw BigQueryException.translateAndThrow(e);
@@ -751,7 +745,7 @@ class ConnectionImpl implements Connection {
 
   private void processArrowStreamAsync(
       ReadSession readSession,
-      BlockingQueue<Tuple<Map<String, Object>, Boolean>> buffer,
+      BlockingQueue<BigQueryResultImpl.Row> buffer,
       ArrowRowReader reader,
       Schema schema) {
 
@@ -778,11 +772,8 @@ class ConnectionImpl implements Connection {
             throw BigQueryException.translateAndThrow(e);
           } finally {
             try {
-              buffer.put(Tuple.of(null, false)); // marking end of stream
-              MoreExecutors.shutdownAndAwaitTermination(
-                  queryTaskExecutor,
-                  EXECUTOR_TIMEOUT_SEC,
-                  TimeUnit.SECONDS); // Shutdown the thread pool
+              buffer.put(new BigQueryResultImpl.Row(null, true)); // marking end of stream
+              queryTaskExecutor.shutdownNow(); // Shutdown the thread pool
             } catch (InterruptedException e) {
               logger.log(Level.WARNING, "\n Error occurred ", e);
             }
@@ -822,9 +813,7 @@ class ConnectionImpl implements Connection {
 
     /** @param batch object returned from the ReadRowsResponse. */
     private void processRows(
-        ArrowRecordBatch batch,
-        BlockingQueue<Tuple<Map<String, Object>, Boolean>> buffer,
-        Schema schema)
+        ArrowRecordBatch batch, BlockingQueue<BigQueryResultImpl.Row> buffer, Schema schema)
         throws IOException { // deserialize the values and consume the hash of the values
       try {
         org.apache.arrow.vector.ipc.message.ArrowRecordBatch deserializedBatch =
@@ -859,7 +848,7 @@ class ConnectionImpl implements Connection {
                     field.getName()); // can be accessed using the index or Vector/column name
             curRow.put(field.getName(), curFieldVec.getObject(rowNum)); // Added the raw value
           }
-          buffer.put(Tuple.of(curRow, true));
+          buffer.put(new BigQueryResultImpl.Row(curRow));
         }
         root.clear(); // TODO: make sure to clear the root while implementing the thread
         // interruption logic (Connection.close method)

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -114,7 +114,7 @@ class ConnectionImpl implements Connection {
    */
   @BetaApi
   @Override
-  public synchronized Boolean close() throws BigQuerySQLException {
+  public synchronized boolean close() throws BigQuerySQLException {
     queryTaskExecutor.shutdownNow();
     try {
       queryTaskExecutor.awaitTermination(

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
@@ -78,7 +78,7 @@ public abstract class ConnectionSettings {
 
   /**
    * Returns whether nested and repeated fields should be flattened. If set to {@code false} {@link
-   * QueryJobConfiguration.Builder#setAllowLargeResults(Boolean)} must be {@code true}.
+   * ConnectionSettings.Builder#setAllowLargeResults(Boolean)} must be {@code true}.
    *
    * @see <a href="https://cloud.google.com/bigquery/docs/data#flatten">Flatten</a>
    */
@@ -302,8 +302,8 @@ public abstract class ConnectionSettings {
     /**
      * Sets whether to look for the result in the query cache. The query cache is a best-effort
      * cache that will be flushed whenever tables in the query are modified. Moreover, the query
-     * cache is only available when {@link
-     * QueryJobConfiguration.Builder#setDestinationTable(TableId)} is not set.
+     * cache is only available when {@link ConnectionSettings.Builder#setDestinationTable(TableId)}
+     * is not set.
      *
      * @see <a href="https://cloud.google.com/bigquery/querying-data#querycaching">Query Caching</a>
      */
@@ -311,7 +311,7 @@ public abstract class ConnectionSettings {
 
     /**
      * Sets whether nested and repeated fields should be flattened. If set to {@code false} {@link
-     * QueryJobConfiguration.Builder#setAllowLargeResults(Boolean)} must be {@code true}. By default
+     * ConnectionSettings.Builder#setAllowLargeResults(Boolean)} must be {@code true}. By default
      * results are flattened.
      *
      * @see <a href="https://cloud.google.com/bigquery/docs/data#flatten">Flatten</a>
@@ -359,7 +359,7 @@ public abstract class ConnectionSettings {
 
     /**
      * Sets the table where to put query results. If not provided a new table is created. This value
-     * is required if {@link QueryJobConfiguration.Builder#setAllowLargeResults(Boolean)} is set to
+     * is required if {@link ConnectionSettings.Builder#setAllowLargeResults(Boolean)} is set to
      * {@code true}.
      */
     public abstract Builder setDestinationTable(TableId destinationTable);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
@@ -210,9 +210,8 @@ public abstract class ConnectionSettings {
     Builder withDefaultValues() {
       return setUseReadAPI(true) // Read API is enabled by default
           .setNumBufferedRows(10000) // 10K records will be kept in the buffer (Blocking Queue)
-          .setMinResultSize(
-              200000) // Read API will be enabled when there will be atleast 100K records
-          .setTotalToPageRowCountRatio(3) // there should be atleast 3 pages  of records
+          .setMinResultSize(200000) // Read API will be enabled when there are at least 100K records
+          .setTotalToPageRowCountRatio(3) // there should be at least 3 pages of records
           .setMaxResultPerPage(100000); // page size for pagination
     }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
@@ -48,6 +48,7 @@ public abstract class ConnectionSettings {
   public abstract List<ConnectionProperty> getConnectionProperties();
 
   /** Returns the default dataset */
+  @Nullable
   public abstract DatasetId getDefaultDataset();
 
   /** Returns the limits the bytes billed for this job */
@@ -268,9 +269,10 @@ public abstract class ConnectionSettings {
     public abstract Builder setMaxResults(Long maxResults);
 
     /**
-     * Sets the number of rows of data to pre-fetch during query execution.
+     * Sets the number of rows in the buffer (a blocking queue) that query results are consumed
+     * from.
      *
-     * @param numBufferedRows prefetchedRowLimit or {@code null} for none
+     * @param numBufferedRows numBufferedRows or {@code null} for none
      */
     public abstract Builder setNumBufferedRows(Integer numBufferedRows);
 
@@ -291,7 +293,7 @@ public abstract class ConnectionSettings {
 
     /**
      * Sets the maximum records per page to be used for pagination. This is used as an input for the
-     * tabledata.list
+     * tabledata.list and jobs.getQueryResults RPC calls
      *
      * @param maxResultPerPage
      */

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
@@ -259,7 +259,7 @@ public interface BigQueryRpc extends ServiceRpc {
    * @throws BigQueryException upon failure
    */
   TableDataList listTableDataWithRowLimit(
-      String projectId, String datasetId, String tableId, Long rowLimit, String pageToken);
+      String projectId, String datasetId, String tableId, Integer rowLimit, String pageToken);
 
   /**
    * Returns the requested job or {@code null} if not found.
@@ -315,7 +315,7 @@ public interface BigQueryRpc extends ServiceRpc {
    * @throws BigQueryException upon failure
    */
   GetQueryResultsResponse getQueryResultsWithRowLimit(
-      String projectId, String jobId, String location, Long preFetchedRowLimit);
+      String projectId, String jobId, String location, Integer preFetchedRowLimit);
 
   /**
    * Runs a BigQuery SQL query synchronously and returns query results if the query completes within

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -533,14 +533,14 @@ public class HttpBigQueryRpc implements BigQueryRpc {
       String projectId,
       String datasetId,
       String tableId,
-      Integer preFetchedRowLimit,
+      Integer maxResultPerPage,
       String pageToken) {
     try {
       return bigquery
           .tabledata()
           .list(projectId, datasetId, tableId)
           .setPrettyPrint(false)
-          .setMaxResults(Long.valueOf(preFetchedRowLimit))
+          .setMaxResults(Long.valueOf(maxResultPerPage))
           .setPageToken(pageToken)
           .execute();
     } catch (IOException ex) {
@@ -697,14 +697,14 @@ public class HttpBigQueryRpc implements BigQueryRpc {
 
   @Override
   public GetQueryResultsResponse getQueryResultsWithRowLimit(
-      String projectId, String jobId, String location, Integer preFetchedRowLimit) {
+      String projectId, String jobId, String location, Integer maxResultPerPage) {
     try {
       return bigquery
           .jobs()
           .getQueryResults(projectId, jobId)
           .setPrettyPrint(false)
           .setLocation(location)
-          .setMaxResults(Long.valueOf(preFetchedRowLimit))
+          .setMaxResults(Long.valueOf(maxResultPerPage))
           .execute();
     } catch (IOException ex) {
       throw translate(ex);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -533,14 +533,14 @@ public class HttpBigQueryRpc implements BigQueryRpc {
       String projectId,
       String datasetId,
       String tableId,
-      Long preFetchedRowLimit,
+      Integer preFetchedRowLimit,
       String pageToken) {
     try {
       return bigquery
           .tabledata()
           .list(projectId, datasetId, tableId)
           .setPrettyPrint(false)
-          .setMaxResults(preFetchedRowLimit)
+          .setMaxResults(Long.valueOf(preFetchedRowLimit))
           .setPageToken(pageToken)
           .execute();
     } catch (IOException ex) {
@@ -697,14 +697,14 @@ public class HttpBigQueryRpc implements BigQueryRpc {
 
   @Override
   public GetQueryResultsResponse getQueryResultsWithRowLimit(
-      String projectId, String jobId, String location, Long preFetchedRowLimit) {
+      String projectId, String jobId, String location, Integer preFetchedRowLimit) {
     try {
       return bigquery
           .jobs()
           .getQueryResults(projectId, jobId)
           .setPrettyPrint(false)
           .setLocation(location)
-          .setMaxResults(preFetchedRowLimit)
+          .setMaxResults(Long.valueOf(preFetchedRowLimit))
           .execute();
     } catch (IOException ex) {
       throw translate(ex);

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
@@ -191,16 +191,22 @@ public class ConnectionImplTest {
             .setCreationTime(1234L)
             .setStartTime(5678L)
             .setQuery(queryMock);
+    com.google.api.services.bigquery.model.JobConfigurationQuery jobConfigurationQuery =
+        new com.google.api.services.bigquery.model.JobConfigurationQuery();
+    com.google.api.services.bigquery.model.JobConfiguration jobConfig =
+        new com.google.api.services.bigquery.model.JobConfiguration()
+            .setQuery(jobConfigurationQuery);
     com.google.api.services.bigquery.model.Job mockDryRunJob =
-        new com.google.api.services.bigquery.model.Job().setStatistics(jobStatsMock);
-    // TODO: figure out why this test is breaking below
-    // when(bigqueryRpcMock.createJobForQuery(any(com.google.api.services.bigquery.model.Job.class)))
-    //     .thenReturn(mockDryRunJob);
-    // BigQueryDryRunResult dryRunResult = connection.dryRun(DRY_RUN_SQL);
-    // assertEquals(1, dryRunResult.getQueryParameters().size());
-    // assertEquals(QUERY_SCHEMA, dryRunResult.getSchema());
-    // verify(bigqueryRpcMock, times(1))
-    //     .createJobForQuery(any(com.google.api.services.bigquery.model.Job.class));
+        new com.google.api.services.bigquery.model.Job()
+            .setStatistics(jobStatsMock)
+            .setConfiguration(jobConfig);
+    when(bigqueryRpcMock.createJobForQuery(any(com.google.api.services.bigquery.model.Job.class)))
+        .thenReturn(mockDryRunJob);
+    BigQueryDryRunResult dryRunResult = connection.dryRun(DRY_RUN_SQL);
+    assertEquals(1, dryRunResult.getQueryParameters().size());
+    assertEquals(QUERY_SCHEMA, dryRunResult.getSchema());
+    verify(bigqueryRpcMock, times(1))
+        .createJobForQuery(any(com.google.api.services.bigquery.model.Job.class));
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
@@ -193,14 +193,14 @@ public class ConnectionImplTest {
             .setQuery(queryMock);
     com.google.api.services.bigquery.model.Job mockDryRunJob =
         new com.google.api.services.bigquery.model.Job().setStatistics(jobStatsMock);
-
-    when(bigqueryRpcMock.createJobForQuery(any(com.google.api.services.bigquery.model.Job.class)))
-        .thenReturn(mockDryRunJob);
-    BigQueryDryRunResult dryRunResult = connection.dryRun(DRY_RUN_SQL);
-    assertEquals(1, dryRunResult.getQueryParameters().size());
-    assertEquals(QUERY_SCHEMA, dryRunResult.getSchema());
-    verify(bigqueryRpcMock, times(1))
-        .createJobForQuery(any(com.google.api.services.bigquery.model.Job.class));
+    // TODO: figure out why this test is breaking below
+    // when(bigqueryRpcMock.createJobForQuery(any(com.google.api.services.bigquery.model.Job.class)))
+    //     .thenReturn(mockDryRunJob);
+    // BigQueryDryRunResult dryRunResult = connection.dryRun(DRY_RUN_SQL);
+    // assertEquals(1, dryRunResult.getQueryParameters().size());
+    // assertEquals(QUERY_SCHEMA, dryRunResult.getSchema());
+    // verify(bigqueryRpcMock, times(1))
+    //     .createJobForQuery(any(com.google.api.services.bigquery.model.Job.class));
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
@@ -172,8 +172,8 @@ public class ConnectionImplTest {
   }
 
   @Test
-  public void testCancel() throws BigQuerySQLException {
-    boolean cancelled = connection.cancel();
+  public void testClose() throws BigQuerySQLException {
+    boolean cancelled = connection.close();
     assertTrue(cancelled);
   }
 

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
@@ -529,9 +529,8 @@ public class ConnectionImplTest {
   public void testGetPageCacheSize() {
     ConnectionImpl connectionSpy = Mockito.spy(connection);
     // number of cached pages should be within a range
-    assertTrue(connectionSpy.getPageCacheSize(10000, 100, QUERY_SCHEMA) >= 3);
-    assertTrue(connectionSpy.getPageCacheSize(100000000, 100, QUERY_SCHEMA) <= 20);
-    verify(connectionSpy, times(2))
-        .getPageCacheSize(any(Integer.class), any(Long.class), any(Schema.class));
+    assertTrue(connectionSpy.getPageCacheSize(10000, QUERY_SCHEMA) >= 3);
+    assertTrue(connectionSpy.getPageCacheSize(100000000, QUERY_SCHEMA) <= 20);
+    verify(connectionSpy, times(2)).getPageCacheSize(any(Integer.class), any(Schema.class));
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
@@ -64,7 +64,7 @@ public class ConnectionImplTest {
       "SELECT  county, state_name FROM bigquery_test_dataset.large_data_testing_table limit 2";
   private static final String DRY_RUN_SQL =
       "SELECT  county, state_name FROM bigquery_test_dataset.large_data_testing_table where country = ?";
-  private static final long DEFAULT_PAGE_SIZE = 10000L;
+  private static final int DEFAULT_PAGE_SIZE = 10000;
   private ConnectionSettings connectionSettings;
   private static final Schema QUERY_SCHEMA =
       Schema.of(
@@ -310,14 +310,14 @@ public class ConnectionImplTest {
   @Test
   public void testGetQueryResultsFirstPage() {
     when(bigqueryRpcMock.getQueryResultsWithRowLimit(
-            any(String.class), any(String.class), any(String.class), any(Long.class)))
+            any(String.class), any(String.class), any(String.class), any(Integer.class)))
         .thenReturn(GET_QUERY_RESULTS_RESPONSE);
     GetQueryResultsResponse response = connection.getQueryResultsFirstPage(QUERY_JOB);
     assertNotNull(response);
     assertEquals(GET_QUERY_RESULTS_RESPONSE, response);
     verify(bigqueryRpcMock, times(1))
         .getQueryResultsWithRowLimit(
-            any(String.class), any(String.class), any(String.class), any(Long.class));
+            any(String.class), any(String.class), any(String.class), any(Integer.class));
   }
 
   // calls executeSelect with a nonFast query and exercises createQueryJob
@@ -529,9 +529,9 @@ public class ConnectionImplTest {
   public void testGetPageCacheSize() {
     ConnectionImpl connectionSpy = Mockito.spy(connection);
     // number of cached pages should be within a range
-    assertTrue(connectionSpy.getPageCacheSize(10000L, 100, QUERY_SCHEMA) >= 3);
-    assertTrue(connectionSpy.getPageCacheSize(100000000L, 100, QUERY_SCHEMA) <= 20);
+    assertTrue(connectionSpy.getPageCacheSize(10000, 100, QUERY_SCHEMA) >= 3);
+    assertTrue(connectionSpy.getPageCacheSize(100000000, 100, QUERY_SCHEMA) <= 20);
     verify(connectionSpy, times(2))
-        .getPageCacheSize(any(Long.class), any(Long.class), any(Schema.class));
+        .getPageCacheSize(any(Integer.class), any(Long.class), any(Schema.class));
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionSettingsTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionSettingsTest.java
@@ -33,14 +33,8 @@ public class ConnectionSettingsTest {
   private static final DatasetId DATASET_ID = DatasetId.of("dataset");
   private static final TableId TABLE_ID = TableId.of("dataset", "table");
   private static final Long REQUEST_TIMEOUT = 10l;
-  private static final Long NUM_BUFFERED_ROWS = 100l;
+  private static final Integer NUM_BUFFERED_ROWS = 100;
   private static final Long MAX_RESULTS = 1000l;
-  private static final ReadClientConnectionConfiguration READ_CLIENT_CONNECTION_CONFIGURATION =
-      ReadClientConnectionConfiguration.newBuilder()
-          .setTotalToPageRowCountRatio(3l)
-          .setMinResultSize(100l)
-          .setBufferSize(100l)
-          .build();
   private static final List<String> SOURCE_URIS = ImmutableList.of("uri1", "uri2");
   private static final String KEY = "time_zone";
   private static final String VALUE = "US/Eastern";
@@ -100,7 +94,6 @@ public class ConnectionSettingsTest {
           .setRequestTimeout(REQUEST_TIMEOUT)
           .setNumBufferedRows(NUM_BUFFERED_ROWS)
           .setMaxResults(MAX_RESULTS)
-          .setReadClientConnectionConfiguration(READ_CLIENT_CONNECTION_CONFIGURATION)
           .setUseQueryCache(USE_QUERY_CACHE)
           .setTableDefinitions(TABLE_DEFINITIONS)
           .setAllowLargeResults(ALLOW_LARGE_RESULTS)
@@ -139,9 +132,6 @@ public class ConnectionSettingsTest {
     assertEquals(REQUEST_TIMEOUT, CONNECTION_SETTINGS.getRequestTimeout());
     assertEquals(NUM_BUFFERED_ROWS, CONNECTION_SETTINGS.getNumBufferedRows());
     assertEquals(MAX_RESULTS, CONNECTION_SETTINGS.getMaxResults());
-    assertEquals(
-        READ_CLIENT_CONNECTION_CONFIGURATION,
-        CONNECTION_SETTINGS.getReadClientConnectionConfiguration());
   }
 
   private void compareConnectionSettings(ConnectionSettings expected, ConnectionSettings value) {
@@ -151,9 +141,6 @@ public class ConnectionSettingsTest {
     assertEquals(expected.getRequestTimeout(), value.getRequestTimeout());
     assertEquals(expected.getNumBufferedRows(), value.getNumBufferedRows());
     assertEquals(expected.getMaxResults(), value.getMaxResults());
-    assertEquals(
-        expected.getReadClientConnectionConfiguration(),
-        value.getReadClientConnectionConfiguration());
     assertEquals(expected.getAllowLargeResults(), value.getAllowLargeResults());
     assertEquals(expected.getCreateDisposition(), value.getCreateDisposition());
     assertEquals(expected.getDefaultDataset(), value.getDefaultDataset());

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3371,7 +3371,7 @@ public class ITBigQueryTest {
         ConnectionSettings.newBuilder().setDefaultDataset(DatasetId.of(DATASET)).build();
     Connection connection = bigquery.createConnection(connectionSettings);
     List<Parameter> parameters = ImmutableList.of(stringParam, timeStampParam);
-    BigQueryResultSet rs = connection.executeSelect(query, parameters, null);
+    BigQueryResultSet rs = connection.executeSelect(query, parameters);
     assertEquals(2, rs.getTotalRows());
   }
 
@@ -3422,7 +3422,7 @@ public class ITBigQueryTest {
         ConnectionSettings.newBuilder().setDefaultDataset(DatasetId.of(DATASET)).build();
     Connection connection = bigquery.createConnection(connectionSettings);
     List<Parameter> parameters = ImmutableList.of(stringParam, intArrayParam);
-    BigQueryResultSet rs = connection.executeSelect(query, parameters, null);
+    BigQueryResultSet rs = connection.executeSelect(query, parameters);
     assertEquals(2, rs.getTotalRows());
   }
 

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -2617,7 +2617,7 @@ public class ITBigQueryTest {
   }
 
   @Test
-  public void testConnectionCancel() throws SQLException {
+  public void testConnectionClose() throws SQLException {
     String query =
         "SELECT date, county, state_name, confirmed_cases, deaths FROM "
             + TABLE_ID_LARGE.getTable()
@@ -2634,7 +2634,7 @@ public class ITBigQueryTest {
     while (rs.next()) {
       ++cnt;
       if (cnt > 57000) { // breaking at 57K, query reads 300K
-        assertTrue(connection.cancel()); // we should be able to cancel the connection
+        assertTrue(connection.close()); // we should be able to cancel the connection
       }
     }
     assertTrue(

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -2345,6 +2345,20 @@ public class ITBigQueryTest {
     assertNotNull(statistics.getQueryPlan());
   }
 
+  // TODO: Uncomment below test case when connectionSettings becomes optional
+  // @Test
+  // public void testExecuteSelect() throws SQLException {
+  //   // Use default connection settings
+  //   Connection connection = bigquery.createConnection();
+  //   String query = "SELECT corpus FROM `bigquery-public-data.samples.shakespeare` GROUP BY
+  // corpus;";
+  //   BigQueryResult bigQueryResult = connection.executeSelect(query);
+  //   ResultSet rs = bigQueryResult.getResultSet();
+  //   while(rs.next()) {
+  //     System.out.println(rs.getString("corpus"));
+  //   }
+  // }
+
   /* TODO(prasmish): replicate the entire test case for executeSelect */
   @Test
   public void testQueryTimeStamp() throws InterruptedException {

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -2345,19 +2345,14 @@ public class ITBigQueryTest {
     assertNotNull(statistics.getQueryPlan());
   }
 
-  // TODO: Uncomment below test case when connectionSettings becomes optional
-  // @Test
-  // public void testExecuteSelect() throws SQLException {
-  //   // Use default connection settings
-  //   Connection connection = bigquery.createConnection();
-  //   String query = "SELECT corpus FROM `bigquery-public-data.samples.shakespeare` GROUP BY
-  // corpus;";
-  //   BigQueryResult bigQueryResult = connection.executeSelect(query);
-  //   ResultSet rs = bigQueryResult.getResultSet();
-  //   while(rs.next()) {
-  //     System.out.println(rs.getString("corpus"));
-  //   }
-  // }
+  @Test
+  public void testExecuteSelectDefaultConnectionSettings() throws SQLException {
+    // Use the default connection settings
+    Connection connection = bigquery.createConnection();
+    String query = "SELECT corpus FROM `bigquery-public-data.samples.shakespeare` GROUP BY corpus;";
+    BigQueryResult bigQueryResult = connection.executeSelect(query);
+    assertEquals(42, bigQueryResult.getTotalRows());
+  }
 
   /* TODO(prasmish): replicate the entire test case for executeSelect */
   @Test
@@ -3450,7 +3445,6 @@ public class ITBigQueryTest {
         QueryParameterValue.timestamp("2014-01-01 07:00:00.000000+00:00");
     Parameter stringParam = Parameter.newBuilder().setValue(stringParameter).build();
     Parameter timeStampParam = Parameter.newBuilder().setValue(timestampParameter).build();
-
     ConnectionSettings connectionSettings =
         ConnectionSettings.newBuilder().setDefaultDataset(DatasetId.of(DATASET)).build();
     Connection connection = bigquery.createConnection(connectionSettings);

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -2709,7 +2709,7 @@ public class ITBigQueryTest {
   public void testReadAPIConnectionMultiClose()
       throws
           SQLException { // use read API to read 300K records, then closes the connection. This test
-                         // repeats it multiple times and assets if the connection was closed
+    // repeats it multiple times and assets if the connection was closed
     String query =
         "SELECT date, county, state_name, confirmed_cases, deaths FROM "
             + TABLE_ID_LARGE.getTable()

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -29,8 +29,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.api.gax.paging.Page;
-import com.google.api.services.bigquery.model.QueryParameter;
-import com.google.api.services.bigquery.model.QueryParameterType;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.Date;
@@ -2495,11 +2493,9 @@ public class ITBigQueryTest {
     assertNotNull(bigQueryDryRunResultSet.getSchema());
     assertEquals(
         BQ_RESULTSET_EXPECTED_SCHEMA, bigQueryDryRunResultSet.getSchema()); // match the schema
-    List<QueryParameter> queryParameters = bigQueryDryRunResultSet.getQueryParameters();
-    List<QueryParameter> expectedQueryParameters =
-        ImmutableList.of(
-            new QueryParameter().setParameterType(new QueryParameterType().setType("STRING")));
-    assertEquals(expectedQueryParameters, queryParameters);
+    List<Parameter> queryParameters = bigQueryDryRunResultSet.getQueryParameters();
+    assertEquals(
+        StandardSQLTypeName.STRING, queryParameters.get(0).getQueryParameterValue().getType());
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
@@ -209,6 +209,9 @@ public class ITNightlyBigQueryTest {
     }
   }
 
+  /*
+  This tests for the order of the records as well as the value of the records using testForAllDataTypeValues
+   */
   @Test
   public void testIterateAndOrder() throws SQLException {
     Connection connection = getConnection();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
@@ -407,11 +407,13 @@ public class ITNightlyBigQueryTest {
     assertEquals("POINT(1 2)", rs.getString("GeographyField"));
 
     // Array type tests
-    JsonStringArrayList<BigDecimal> ary = (JsonStringArrayList) rs.getObject("IntegerArrayField");
-    assertEquals(3, ary.size());
-    assertEquals(1, ary.get(0).intValue());
-    assertEquals(2, ary.get(1).intValue());
-    assertEquals(3, ary.get(2).intValue());
+    if (rs.getObject("IntegerArrayField") instanceof JsonStringArrayList) {
+      JsonStringArrayList<BigDecimal> ary = (JsonStringArrayList) rs.getObject("IntegerArrayField");
+      assertEquals(3, ary.size());
+      assertEquals(1, ary.get(0).intValue());
+      assertEquals(2, ary.get(1).intValue());
+      assertEquals(3, ary.get(2).intValue());
+    }
 
     // BigNumeric, int and Numeric
     assertTrue(10000000L + cnt == rs.getDouble("BigNumericField"));

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
@@ -37,9 +37,7 @@ import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.Parameter;
-import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
-import com.google.cloud.bigquery.ReadClientConnectionConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.StandardTableDefinition;
@@ -79,9 +77,9 @@ public class ITNightlyBigQueryTest {
   private static final byte[] BYTES = "TestByteValue".getBytes(StandardCharsets.UTF_8);
   private static final String BYTES_BASE64 = BaseEncoding.base64().encode(BYTES);
   // Script will populate NUM_BATCHES*REC_PER_BATCHES number of records (eg: 100*10000 = 1M)
-  private static final int NUM_BATCHES = 35;
+  private static final int NUM_BATCHES = 55;
   private static final int REC_PER_BATCHES = 10000;
-  private static final int LIMIT_RECS = 300000; // We can plan to read ~ 1M records
+  private static final int LIMIT_RECS = 500000; // We can plan to read ~ 500K / 1M records
   private static final int MULTI_LIMIT_RECS =
       300000; // Used for multiquery testcase, a lower limit like 300K should be fine
   private static int rowCnt = 0;
@@ -513,22 +511,11 @@ public class ITNightlyBigQueryTest {
   }
 
   private Connection getConnection() {
-    ReadClientConnectionConfiguration clientConnectionConfiguration =
-        ReadClientConnectionConfiguration.newBuilder()
-            .setTotalToPageRowCountRatio(10L)
-            .setMinResultSize(200000L)
-            .setBufferSize(10000L)
-            .build();
+
     ConnectionSettings connectionSettings =
         ConnectionSettings.newBuilder()
             .setDefaultDataset(DatasetId.of(DATASET))
-            .setNumBufferedRows(10000L) // page size
-            .setPriority(
-                QueryJobConfiguration.Priority
-                    .INTERACTIVE) // so that isFastQuerySupported returns false
-            .setReadClientConnectionConfiguration(clientConnectionConfiguration)
-            .setUseReadAPI(true)
-            .build();
+            .build(); // Read API is enabled by default
     return bigquery.createConnection(connectionSettings);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-bigquery-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.10.10-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+  <version>2.10.11-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
   <name>BigQuery Parent</name>
   <url>https://github.com/googleapis/java-bigquery</url>
   <description>
@@ -99,7 +99,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery</artifactId>
-        <version>2.10.10-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+        <version>2.10.11-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
       </dependency>
 
       <dependency>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>2.6.1</version>
+      <version>2.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>2.10.10-SNAPSHOT</version>
+      <version>2.10.11-SNAPSHOT</version>
     </dependency>
     <!-- {x-version-update-end} -->
     <dependency>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>2.6.1</version>
+      <version>2.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>2.6.1</version>
+      <version>2.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-bigquery:2.10.9:2.10.10-SNAPSHOT
+google-cloud-bigquery:2.10.10:2.10.11-SNAPSHOT


### PR DESCRIPTION
Background: [go/bq-sql-client-java](https://goto.google.com/bq-sql-client-java)

This PR provides a completely new Connection interface which defines separate APIs for different types of queries. This allows us to provide an industry standard way for database applications to build against the Java client library. We provide 3 new [JDBC-esque](https://docs.oracle.com/javase/7/docs/api/java/sql/Statement.html) API methods:

**[In-scope for this PR] executeSelect - Only supports read only SELECT queries.**
[Not in this PR] executeUpdate - Only supports DML and DDL. 
[Not in this PR] execute - Any SQL - scripts, DML, DDL, SELECT etc statements.

We also integrate with the [BigQueryStorage client library](https://github.com/googleapis/java-bigquerystorage) and use the high throughput Read API when applicable to parse query results using Arrow format. Arrow has shown better performance over Avro as the row serialization format in this [experiment](http://go/bq-java-client-library-arrow-vs-avro).