### PR TITLE
fix: bug fix for get method of Bigquery Dataset

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Dataset.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Dataset.java
@@ -23,6 +23,7 @@ import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQuery.DatasetOption;
 import com.google.cloud.bigquery.BigQuery.TableListOption;
 import com.google.cloud.bigquery.BigQuery.TableOption;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.List;
@@ -275,8 +276,13 @@ public class Dataset extends DatasetInfo {
    * @throws BigQueryException upon failure
    */
   public Table get(String tableId, TableOption... options) {
-   //Adding the projectId used of getting the DataSet as a parameter for the issue: https://github.com/googleapis/java-bigquery/issues/1369
-     return bigquery.getTable(TableId.of(getDatasetId().getProject(), getDatasetId().getDataset(), tableId), options);
+    // Adding the projectId used of getting the DataSet as a parameter for the issue:
+    // https://github.com/googleapis/java-bigquery/issues/1369
+    TableId tabId =
+        Strings.isNullOrEmpty(getDatasetId().getProject())
+            ? TableId.of(getDatasetId().getDataset(), tableId)
+            : TableId.of(getDatasetId().getProject(), getDatasetId().getDataset(), tableId);
+    return bigquery.getTable(tabId, options);
   }
 
   /**

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Dataset.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Dataset.java
@@ -275,7 +275,8 @@ public class Dataset extends DatasetInfo {
    * @throws BigQueryException upon failure
    */
   public Table get(String tableId, TableOption... options) {
-    return bigquery.getTable(TableId.of(getDatasetId().getDataset(), tableId), options);
+   //Adding the projectId used of getting the DataSet as a parameter for the issue: https://github.com/googleapis/java-bigquery/issues/1369
+     return bigquery.getTable(TableId.of(getDatasetId().getProject(), getDatasetId().getDataset(), tableId), options);
   }
 
   /**

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetTest.java
@@ -77,6 +77,12 @@ public class DatasetTest {
       TableInfo.newBuilder(TableId.of("dataset", "table2"), VIEW_DEFINITION).build();
   private static final TableInfo TABLE_INFO3 =
       TableInfo.newBuilder(TableId.of("dataset", "table3"), EXTERNAL_TABLE_DEFINITION).build();
+  private static final String NEW_PROJECT_ID = "projectId2";
+  private static final TableId TABLE_ID1 = TableId.of(NEW_PROJECT_ID, "dataset", "table3");
+  private static final TableInfo TABLE_INFO4 =
+      TableInfo.newBuilder(
+              TableId.of(NEW_PROJECT_ID, "dataset", "table3"), EXTERNAL_TABLE_DEFINITION)
+          .build();
 
   @Rule public MockitoRule rule;
 
@@ -253,6 +259,16 @@ public class DatasetTest {
     assertNotNull(table);
     assertEquals(expectedTable, table);
     verify(bigquery).getTable(TABLE_INFO1.getTableId());
+  }
+
+  @Test
+  public void testGetTableWithNewProjectId() {
+    Table expectedTable = new Table(bigquery, new TableInfo.BuilderImpl(TABLE_INFO4));
+    when(bigquery.getTable(TABLE_ID1, null)).thenReturn(expectedTable);
+    Table table = bigquery.getTable(TABLE_ID1, null);
+    assertNotNull(table);
+    assertEquals(table.getTableId().getProject(), NEW_PROJECT_ID);
+    verify(bigquery).getTable(TABLE_ID1, null);
   }
 
   @Test


### PR DESCRIPTION
Fixed `Dataset.get(String tableId, TableOption... options)` method's implementation to use the projectId associated with DatasetId, if one is present. Otherwise default to Bigquery's instance's projectId. Added test case.  

Fixes #1369  ☕️
