### PR TITLE
samples: use a uuid for insert id in streaming insert with row id example

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigquery/TableInsertRows.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/TableInsertRows.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigquery.TableId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 // Sample to inserting rows into a table without running a load job.
 public class TableInsertRows {
@@ -58,9 +59,8 @@ public class TableInsertRows {
           bigquery.insertAll(
               InsertAllRequest.newBuilder(tableId)
                   // More rows can be added in the same RPC by invoking .addRow() on the builder.
-                  // You can also supply optional unique row keys to support de-duplication
-                  // scenarios.
-                  .addRow(rowContent)
+                  // The insert ID used for de-duplication here is best effort.
+                  .addRow(/*id=*/ UUID.randomUUID().toString(), rowContent)
                   .build());
 
       if (response.hasErrors()) {


### PR DESCRIPTION
IIUC, the first streaming insert Java sample [here](https://cloud.google.com/bigquery/streaming-data-into-bigquery#streaminginsertexamples) is supposed to show streaming inserts with insert IDs, which the Java client calls `id` and does not populate using UUID if unset.

- Go calls it `insertId` and autopopulates it: https://pkg.go.dev/cloud.google.com/go/bigquery#ValuesSaver
- Python called it `row_id` and under the hood implements it via a `insertId` if unset https://github.com/googleapis/python-bigquery/blob/master/google/cloud/bigquery/client.py#L3423

---
Also see internal cl/382167079