### PR TITLE
fix: fix timestamp rounding issue

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
@@ -184,6 +184,9 @@ public class FieldValue implements Serializable {
     // timestamps are encoded in the format 1408452095.22 where the integer part is seconds since
     // epoch (e.g. 1408452095.22 == 2014-08-19 07:41:35.220 -05:00)
     BigDecimal secondsWithMicro = new BigDecimal(getStringValue());
+    // Rounding the BigDecimal to the nearest whole number before setting the longValue in order to
+    // address TimeStamp rounding issue described in
+    // https://github.com/googleapis/java-bigquery/issues/1644
     BigDecimal scaled = secondsWithMicro.scaleByPowerOfTen(6).setScale(0, RoundingMode.HALF_UP);
     return scaled.longValue();
   }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -183,7 +184,7 @@ public class FieldValue implements Serializable {
     // timestamps are encoded in the format 1408452095.22 where the integer part is seconds since
     // epoch (e.g. 1408452095.22 == 2014-08-19 07:41:35.220 -05:00)
     BigDecimal secondsWithMicro = new BigDecimal(getStringValue());
-    BigDecimal scaled = secondsWithMicro.scaleByPowerOfTen(6);
+    BigDecimal scaled = secondsWithMicro.scaleByPowerOfTen(6).setScale(0, RoundingMode.HALF_UP);
     return scaled.longValue();
   }
 

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -127,6 +127,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1852,6 +1853,40 @@ public class ITBigQueryTest {
     Job job2 = bigquery.getJob(job.getJobId());
     JobStatistics.QueryStatistics statistics = job2.getStatistics();
     assertNotNull(statistics.getQueryPlan());
+  }
+
+  @Test
+  public void testQueryTimeStamp() throws InterruptedException {
+    String query = "SELECT TIMESTAMP '2022-01-24T23:54:25.095574Z'";
+    Instant beforeQueryInstant = Instant.parse("2022-01-24T23:54:25.095574Z");
+    long microsBeforeQuery =
+        TimeUnit.SECONDS.toMicros(beforeQueryInstant.getEpochSecond())
+            + TimeUnit.NANOSECONDS.toMicros(beforeQueryInstant.getNano());
+
+    // Verify that timestamp remains the same when priority is set to INTERACTIVE
+    TableResult result =
+        bigquery.query(
+            QueryJobConfiguration.newBuilder(query)
+                .setDefaultDataset(DatasetId.of(DATASET))
+                .setPriority(QueryJobConfiguration.Priority.INTERACTIVE)
+                .build());
+    for (FieldValueList row : result.getValues()) {
+      FieldValue timeStampCell = row.get(0);
+      long microsAfterQuery = timeStampCell.getTimestampValue();
+      assertEquals(microsBeforeQuery, microsAfterQuery);
+    }
+
+    // Verify that timestamp remains the same without priority set to INTERACTIVE
+    TableResult resultInteractive =
+        bigquery.query(
+            QueryJobConfiguration.newBuilder(query)
+                .setDefaultDataset(DatasetId.of(DATASET))
+                .build());
+    for (FieldValueList row : resultInteractive.getValues()) {
+      FieldValue timeStampCell = row.get(0);
+      long microsAfterQuery = timeStampCell.getTimestampValue();
+      assertEquals(microsBeforeQuery, microsAfterQuery);
+    }
   }
 
   @Test


### PR DESCRIPTION
Towards #1644

Temp fix timestamp rounding error (to microsecond) which can be reproduced by setting query priority to `INTERACTIVE`. 
