### PR TITLE
fix: removing a new line character in a property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-bigquery-parent</site.installationModule>
-    <google-api-services-bigquery.version>v2-rev20211017-1.32.1
-    </google-api-services-bigquery.version>
+    <google-api-services-bigquery.version>v2-rev20211017-1.32.1</google-api-services-bigquery.version>
     <google.cloud.shared-dependencies.version>2.4.0</google.cloud.shared-dependencies.version>
   </properties>
 


### PR DESCRIPTION
I found the pom.xml has a strange white space character in pom.xml.

<img width="940" alt="Screen Shot 2021-11-12 at 3 04 12 PM" src="https://user-images.githubusercontent.com/28604/141528261-54981ad9-afe0-4767-aa12-dabf55818090.png">

Maybe Maven just ignores such white space characters but it's better to fix it.