### PR TITLE
feat: set Table.Schema for permanent external tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:24.0.0')
+implementation platform('com.google.cloud:libraries-bom:24.4.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.3.3'
+implementation 'com.google.cloud:google-cloud-bigquery:2.9.4'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.3.3"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.9.4"
 ```
 
 ## Authentication

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -286,6 +286,12 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                     ? getOptions().getProjectId()
                     : tableInfo.getTableId().getProject())
             .toPb();
+    // Set schema on the Table for permanent external table
+    if (tablePb.getExternalDataConfiguration() != null) {
+      tablePb.setSchema(tablePb.getExternalDataConfiguration().getSchema());
+      // clear table schema on ExternalDataConfiguration
+      tablePb.getExternalDataConfiguration().setSchema(null);
+    }
     final Map<BigQueryRpc.Option, ?> optionsMap = optionMap(options);
     try {
       return Table.fromPb(

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -954,6 +954,28 @@ public class ITBigQueryTest {
   }
 
   @Test
+  public void testSetPermExternalTableSchema() {
+    String tableName = "test_create_external_table_perm";
+    TableId tableId = TableId.of(DATASET, tableName);
+    ExternalTableDefinition externalTableDefinition =
+        ExternalTableDefinition.newBuilder(
+                "gs://" + BUCKET + "/" + JSON_LOAD_FILE, FormatOptions.json())
+            .setSchema(TABLE_SCHEMA)
+            .setConnectionId(
+                // TODO: SET UP CONNECTION FOR THE TEST
+                "projects/java-docs-samples-testing/locations/us/connections/[TODO:CONNECTION]")
+            .build();
+    TableInfo tableInfo = TableInfo.of(tableId, externalTableDefinition);
+    // Table createdTable = bigquery.create(tableInfo);
+    //
+    // assertNotNull(createdTable);
+    // assertEquals(DATASET, createdTable.getTableId().getDataset());
+    // assertEquals(tableName, createdTable.getTableId().getTable());
+    // Table remoteTable = bigquery.getTable(DATASET, tableName);
+    // assertNotNull(remoteTable);
+  }
+
+  @Test
   public void testCreateViewTable() throws InterruptedException {
     String tableName = "test_create_view_table";
     TableId tableId = TableId.of(DATASET, tableName);

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -962,17 +962,17 @@ public class ITBigQueryTest {
                 "gs://" + BUCKET + "/" + JSON_LOAD_FILE, FormatOptions.json())
             .setSchema(TABLE_SCHEMA)
             .setConnectionId(
-                // TODO: SET UP CONNECTION FOR THE TEST
-                "projects/java-docs-samples-testing/locations/us/connections/[TODO:CONNECTION]")
+                "projects/java-docs-samples-testing/locations/us/connections/DEVREL_TEST_CONNECTION")
             .build();
     TableInfo tableInfo = TableInfo.of(tableId, externalTableDefinition);
-    // Table createdTable = bigquery.create(tableInfo);
-    //
-    // assertNotNull(createdTable);
-    // assertEquals(DATASET, createdTable.getTableId().getDataset());
-    // assertEquals(tableName, createdTable.getTableId().getTable());
-    // Table remoteTable = bigquery.getTable(DATASET, tableName);
-    // assertNotNull(remoteTable);
+    Table createdTable = bigquery.create(tableInfo);
+
+    assertNotNull(createdTable);
+    assertEquals(DATASET, createdTable.getTableId().getDataset());
+    assertEquals(tableName, createdTable.getTableId().getTable());
+    Table remoteTable = bigquery.getTable(DATASET, tableName);
+    assertNotNull(remoteTable);
+    assertTrue(remoteTable.delete());
   }
 
   @Test


### PR DESCRIPTION
Per discussion related to go/bq-external-table-schema