### PR TITLE
fix: added the closing tag for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-bigquery</artifactId>
   </dependency>
-
+</dependencies>
+  
 ```
 
 If you are using Maven without BOM, add this to your dependencies:


### PR DESCRIPTION
I found that the maven dependency for the google-cloud-bigquery was incomplete while I was revisiting the code. Hence, added the required closing tag to fix the issue.