### PR TITLE
chore: added the closing tag for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-bigquery</artifactId>
   </dependency>
+</dependencies>
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-bigquery</artifactId>
   </dependency>
-</dependencies>
 
 ```
 
@@ -52,7 +51,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:24.0.0')
+implementation platform('com.google.cloud:libraries-bom:24.1.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```


### PR DESCRIPTION
I found that the maven dependency for the google-cloud-bigquery was incomplete while I was revisiting the code. Hence, added the required closing tag to fix the issue.