### PR TITLE
docs: fix query pagination sample

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigquery/QueryPagination.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/QueryPagination.java
@@ -21,7 +21,6 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.QueryJobConfiguration;
-import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 
 // Sample to run query with pagination.
@@ -45,17 +44,13 @@ public class QueryPagination {
       // once, and can be reused for multiple requests.
       BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
 
-      TableId tableId = TableId.of(datasetName, tableName);
       QueryJobConfiguration queryConfig =
           QueryJobConfiguration.newBuilder(query)
               // save results into a table.
               .setDestinationTable(tableId)
               .build();
 
-      bigquery.query(queryConfig);
-
-      TableResult results =
-          bigquery.listTableData(tableId, BigQuery.TableDataListOption.pageSize(20));
+      TableResult results = bigquery.query(queryConfig);
 
       // First Page
       results


### PR DESCRIPTION
Sample code was misleading; it ran a query, then read from a table.
It did not, in fact, read the query results.

This has caused confusion for users;
https://stackoverflow.com/questions/70509827/bigquery-client-bigquery-listtabledata-with-filter-condition
is an example where a user is confused by the behavior because they're
starting with broken code in the first place.
