### PR TITLE
fix(java): add additional configurations to fix native image tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.8.0'
+implementation 'com.google.cloud:google-cloud-bigquery:2.9.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.8.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.9.0"
 ```
 
 ## Authentication

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -129,7 +129,6 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -471,8 +470,8 @@ public class ITBigQueryTest {
             .setContentType("application/json")
             .build(),
         JSON_CONTENT_SIMPLE.getBytes(StandardCharsets.UTF_8));
-    InputStream stream = ITBigQueryTest.class.getClassLoader()
-        .getResourceAsStream("QueryTestData.csv");
+    InputStream stream =
+        ITBigQueryTest.class.getClassLoader().getResourceAsStream("QueryTestData.csv");
     storage.createFrom(
         BlobInfo.newBuilder(BUCKET, LOAD_FILE_LARGE).setContentType("text/plain").build(), stream);
     DatasetInfo info =

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -125,6 +125,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.google.gson.JsonObject;
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -470,9 +471,10 @@ public class ITBigQueryTest {
             .setContentType("application/json")
             .build(),
         JSON_CONTENT_SIMPLE.getBytes(StandardCharsets.UTF_8));
+    InputStream stream = ITBigQueryTest.class.getClassLoader()
+        .getResourceAsStream("QueryTestData.csv");
     storage.createFrom(
-        BlobInfo.newBuilder(BUCKET, LOAD_FILE_LARGE).setContentType("text/plain").build(),
-        FileSystems.getDefault().getPath("src/test/resources", "QueryTestData.csv"));
+        BlobInfo.newBuilder(BUCKET, LOAD_FILE_LARGE).setContentType("text/plain").build(), stream);
     DatasetInfo info =
         DatasetInfo.newBuilder(DATASET).setDescription(DESCRIPTION).setLabels(LABELS).build();
     bigquery.create(info);

--- a/google-cloud-bigquery/src/test/resources/META-INF/native-image/reflect-config.json
+++ b/google-cloud-bigquery/src/test/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name":"java.lang.Object",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "name":"com.google.api.client.googleapis.json.GoogleJsonError",
+    "methods":[
+      {"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "name":"com.google.api.client.googleapis.json.GoogleJsonError$Details",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "name":"com.google.api.client.googleapis.json.GoogleJsonError$ErrorInfo",
+    "methods":[{"name":"<init>","parameterTypes":[]}]
+  },
+  {
+    "name":"java.util.HashMap",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  }
+]

--- a/google-cloud-bigquery/src/test/resources/META-INF/native-image/resource-config.json
+++ b/google-cloud-bigquery/src/test/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,3 @@
+{
+  "resources":[{"pattern": ".*.csv"}]
+}


### PR DESCRIPTION
This PR explicitly specifies the resource (in this case, `QueryTestData.csv`) that needs to be accessible at run-time through the use of the `resource-config.json` file. Using this json config file allows the resource to be accessible when [methods such as Class.getResource() and Class.getResourceAsStream() are used](https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/Resources.md). However, referencing a resource using the full path still results in the `NoSuchFileException`. 

This PR also adds some additional reflection configuration to resolve the following issues:

```
 Caused by: java.lang.IllegalArgumentException: field private java.util.List com.google.api.client.googleapis.json.GoogleJsonError.details
       com.google.api.client.json.JsonParser.parseValue(JsonParser.java:900)
       com.google.api.client.json.JsonParser.parse(JsonParser.java:451)
       com.google.api.client.json.JsonParser.parseValue(JsonParser.java:787)
       [...]
Caused by: java.lang.IllegalArgumentException: field private java.util.List com.google.api.client.googleapis.json.GoogleJsonError.details
       com.google.api.client.json.JsonParser.parseValue(JsonParser.java:900)
       com.google.api.client.json.JsonParser.parseArray(JsonParser.java:641)
       com.google.api.client.json.JsonParser.parseValue(JsonParser.java:744)
       [...]
...
MethodSource [className = 'com.google.cloud.bigquery.it.ITBigQueryTest', methodName = 'testUpdateDataset', methodParameterTypes = '']
    => java.lang.IllegalArgumentException: unable to create new instance of class java.util.HashMap because it has no accessible default constructor
       com.google.api.client.util.Types.handleExceptionForNewInstance(Types.java:162)
       com.google.api.client.util.Types.newInstance(Types.java:117)
       com.google.api.client.util.Data.createNullInstance(Data.java:166)
       com.google.api.client.util.Data.nullOf(Data.java:134)
       com.google.cloud.bigquery.Labels.toPb(Labels.java:44)

```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1848 ☕️
