### PR TITLE
chore: restructure dependencies for the new features related to bigquerystorage Java client

### DIFF
--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -93,6 +93,31 @@
       <groupId>org.threeten</groupId>
       <artifactId>threeten-extra</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquerystorage</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigquerystorage-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-netty</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- auto-value creates a class that uses an annotation from error_prone_annotations -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,21 +66,39 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- BOM for bigquerystorage-->
-      <!--    <dependency>
-           <groupId>com.google.cloud</groupId>
-           <artifactId>libraries-bom</artifactId>
-           <version>24.2.0</version>
-           <type>pom</type>
-           <scope>import</scope>
-         </dependency>-->
-         <dependency>
-           <groupId>com.google.cloud</groupId>
-           <artifactId>google-cloud-datacatalog-bom</artifactId>
-           <version>1.6.1</version>
-           <type>pom</type>
-           <scope>import</scope>
-         </dependency>
+
+      <!-- Used for BQ Storage APIs -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigquerystorage-bom</artifactId>
+        <version>2.8.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-vector</artifactId>
+        <version>7.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-memory-core</artifactId>
+        <version>7.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-memory-netty</artifactId>
+        <version>7.0.0</version>
+        <scope>runtime</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>com.google.cloud</groupId>
+         <artifactId>google-cloud-datacatalog-bom</artifactId>
+         <version>1.6.1</version>
+         <type>pom</type>
+         <scope>import</scope>
+       </dependency>
 
       <dependency>
         <groupId>com.google.cloud</groupId>
@@ -169,40 +187,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <dependencies>
-    <!-- Dependency for bigquerystorage-->
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-bigquerystorage</artifactId>
-      <version>2.8.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>proto-google-cloud-bigquerystorage-v1</artifactId>
-      <version>2.8.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.arrow</groupId>
-      <artifactId>arrow-vector</artifactId>
-      <version>7.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.arrow</groupId>
-      <artifactId>arrow-memory-core</artifactId>
-      <version>7.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.arrow</groupId>
-      <artifactId>arrow-memory-netty</artifactId>
-      <version>7.0.0</version>
-      <scope>runtime</scope>
-    </dependency>
-  </dependencies>
 
   <modules>
     <module>google-cloud-bigquery</module>


### PR DESCRIPTION
Relates to https://github.com/googleapis/java-bigquery/pull/1374

- Use google-cloud-bigquerystorage BOM to manage all the related dependency versions.
- Use dependencyManagement to manager version numbers