### PR TITLE
fix: NPE issue with testMultipleRuns

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.2.0')
+implementation platform('com.google.cloud:libraries-bom:25.3.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.11.0'
+implementation 'com.google.cloud:google-cloud-bigquery:2.11.1'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.11.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.11.1"
 ```
 
 ## Authentication

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -237,7 +237,7 @@ class ConnectionImpl implements Connection {
         && firstPage.getTotalRows() != null
         && firstPage.getSchema()
             != null) { // firstPage.getTotalRows() is null if job is not complete. We need to make
-                       // sure that the schema is not null, as it is required for the ResultSet
+      // sure that the schema is not null, as it is required for the ResultSet
       return getSubsequentQueryResultsWithJob(
           firstPage.getTotalRows().longValue(),
           (long) firstPage.getRows().size(),

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -234,8 +234,10 @@ class ConnectionImpl implements Connection {
   BigQueryResult getResultSet(
       GetQueryResultsResponse firstPage, JobId jobId, String sql, Boolean hasQueryParameters) {
     if (firstPage.getJobComplete()
-        && firstPage.getTotalRows()
-            != null) { // firstPage.getTotalRows() is null if job is not complete
+        && firstPage.getTotalRows() != null
+        && firstPage.getSchema()
+            != null) { // firstPage.getTotalRows() is null if job is not complete. We need to make
+                       // sure that the schema is not null, as it is required for the ResultSet
       return getSubsequentQueryResultsWithJob(
           firstPage.getTotalRows().longValue(),
           (long) firstPage.getRows().size(),


### PR DESCRIPTION
Added a `null` check for  `firstPage.getSchema()` as we might get null schema when the job is long running (We get schema using dryRun in such cases)

Fixes #2049 ☕️
