### PR TITLE
fix: Flaky testPositionalQueryParameters

### DIFF
--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3441,7 +3441,6 @@ public class ITBigQueryTest {
       // https://github.com/googleapis/java-bigquery/issues/2056. String comparison of values, eg
       // 1.40845209522E9 vs 1408452095.22 seems to be failing, so comparing the values as epoc
       // (Long) instead
-      // Double.parseDouble("1.40845209522E9").
       assertEquals(
           (long) Double.parseDouble("1.40845209522E9"),
           (long) Double.parseDouble(values.get(0).getValue().toString()));

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3438,7 +3438,13 @@ public class ITBigQueryTest {
     assertEquals(QUERY_RESULT_SCHEMA_BIGNUMERIC, result.getSchema());
     assertEquals(2, Iterables.size(result.getValues()));
     for (FieldValueList values : result.iterateAll()) {
-      assertEquals("1.40845209522E9", values.get(0).getValue());
+      // https://github.com/googleapis/java-bigquery/issues/2056. String comparison of values, eg
+      // 1.40845209522E9 vs 1408452095.22 seems to be failing, so comparing the values as epoc
+      // (Long) instead
+      // Double.parseDouble("1.40845209522E9").
+      assertEquals(
+          (long) Double.parseDouble("1.40845209522E9"),
+          (long) Double.parseDouble(values.get(0).getValue().toString()));
       assertEquals("stringValue", values.get(1).getValue());
       assertEquals(false, values.get(2).getBooleanValue());
       assertEquals("0.33333333333333333333333333333333333333", values.get(3).getValue());


### PR DESCRIPTION
String comparison of values, eg `1.40845209522E9` vs `1408452095.22` seems to be failing, so comparing the values as epoc (Long) instead

Fixes #2056 ☕️

