### PR TITLE
chore: manage dependency updates from renovate-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.11.2'
+implementation 'com.google.cloud:google-cloud-bigquery:2.12.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.11.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.12.0"
 ```
 
 ## Authentication

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,7 @@
     {
       "packagePatterns": [
         "^com.google.cloud:google-cloud-bigquery",
+        "^com.google.cloud:google-cloud-bigtable",
         "^com.google.cloud:libraries-bom",
         "^com.google.cloud.samples:shared-configuration"
       ],
@@ -70,10 +71,11 @@
     {
       "packagePatterns": [
         "^com.google.api.grpc:proto-google-cloud-datacatalog",
-        "^com.google.cloud:google-cloud-datacatalog"
+        "^com.google.cloud:google-cloud-datacatalog",
+        "^com.google.cloud:google-cloud-bigquerystorage-bom",
+        "^com.google.cloud:google-cloud-storage"
       ],
-      "groupName": "datacatalog dependencies",
-      "semanticCommitType": "test",
+      "groupName": "cloud client dependencies",
       "semanticCommitScope": "deps"
     }
   ],


### PR DESCRIPTION
to address issues like:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/7338432/170315704-198c7168-6334-4826-9e7c-2709fd0bb0f8.png">
which occurs since shared-dependencies updates take different amount of time to roll out in various cloud clients.

[Full trace](https://github.com/googleapis/java-bigquery/runs/6578164174?check_suite_focus=true)

In this PR, we group the GCP Java client dependencies together so that their updates will be proposed in one single PR when they get updated:
```
        "^com.google.cloud:google-cloud-datacatalog",
        "^com.google.cloud:google-cloud-bigquerystorage-bom",
        "^com.google.cloud:google-cloud-storage"
```

In addition, we classify `^com.google.cloud:google-cloud-bigtable` as a `chore` dependency update since it is only used in samples and it should not result in a client library version bump.