### PR TITLE
chore: NPE in testConnectionClose

### DIFF
--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -2724,6 +2724,15 @@ public class ITBigQueryTest {
     connection.close();
   }
 
+  // Ref: https://github.com/googleapis/java-bigquery/issues/2070. Adding a pre-submit test to see
+  // if bigquery.createConnection() returns null
+  @Test
+  public void testCreateDefaultConnection() throws BigQuerySQLException {
+    Connection connection = bigquery.createConnection();
+    assertNotNull("bigquery.createConnection() returned null", connection);
+    assertTrue(connection.close());
+  }
+
   @Test
   public void testReadAPIConnectionMultiClose()
       throws

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
@@ -341,6 +341,7 @@ public class ITNightlyBigQueryTest {
   @Test
   public void testConnectionClose() throws SQLException {
     Connection connection = bigquery.createConnection();
+    assertNotNull("bigquery.createConnection() returned null", connection);
     BigQueryResult bigQueryResult = connection.executeSelect(QUERY);
     logger.log(Level.INFO, "Query used: {0}", QUERY);
     ResultSet rs = bigQueryResult.getResultSet();


### PR DESCRIPTION
Adding a pre-submit testcase and an assertion in testConnectionClose to check if `connection` becomes `null`. It must not as the line `bigquery.createConnection()` doesn't error out and this must always return an instance of `ConnectionImpl`

Fixes #2070 ☕️
