### PR TITLE
feat(bigquery): enable use of GEOGRAPHY query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.4.0')
+implementation platform('com.google.cloud:libraries-bom:26.0.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
@@ -258,10 +258,10 @@ public abstract class QueryParameterValue implements Serializable {
     return of(value, StandardSQLTypeName.STRING);
   }
 
-    /** Creates a {@code QueryParameterValue} object with a type of GEOGRAPHY. */
-    public static QueryParameterValue geography(String value) {
-      return of(value, StandardSQLTypeName.GEOGRAPHY);
-    }
+  /** Creates a {@code QueryParameterValue} object with a type of GEOGRAPHY. */
+  public static QueryParameterValue geography(String value) {
+    return of(value, StandardSQLTypeName.GEOGRAPHY);
+  }
 
   /**
    * Creates a {@code QueryParameterValue} object with a type of JSON. Currently, this is only

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
@@ -374,6 +374,8 @@ public abstract class QueryParameterValue implements Serializable {
       return StandardSQLTypeName.BOOL;
     } else if (String.class.isAssignableFrom(type)) {
       return StandardSQLTypeName.STRING;
+    } else if (String.class.isAssignableFrom(type)) {
+      return StandardSQLTypeName.GEOGRAPHY;
     } else if (Integer.class.isAssignableFrom(type)) {
       return StandardSQLTypeName.INT64;
     } else if (Long.class.isAssignableFrom(type)) {
@@ -426,6 +428,8 @@ public abstract class QueryParameterValue implements Serializable {
         }
         break;
       case STRING:
+        return value.toString();
+      case GEOGRAPHY:
         return value.toString();
       case JSON:
         if (value instanceof String || value instanceof JsonObject) return value.toString();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
@@ -258,6 +258,11 @@ public abstract class QueryParameterValue implements Serializable {
     return of(value, StandardSQLTypeName.STRING);
   }
 
+    /** Creates a {@code QueryParameterValue} object with a type of GEOGRAPHY. */
+    public static QueryParameterValue geography(String value) {
+      return of(value, StandardSQLTypeName.GEOGRAPHY);
+    }
+
   /**
    * Creates a {@code QueryParameterValue} object with a type of JSON. Currently, this is only
    * supported in INSERT, not in query as a filter

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryParameterValueTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryParameterValueTest.java
@@ -197,6 +197,15 @@ public class QueryParameterValueTest {
   }
 
   @Test
+  public void testGeography() {
+    QueryParameterValue value = QueryParameterValue.geography("POINT(-122.350220 47.649154)");
+    assertThat(value.getValue()).isEqualTo("POINT(-122.350220 47.649154)");
+    assertThat(value.getType()).isEqualTo(StandardSQLTypeName.GEOGRAPHY);
+    assertThat(value.getArrayType()).isNull();
+    assertThat(value.getArrayValues()).isNull();
+  }
+
+  @Test
   public void testJson() {
     QueryParameterValue value =
         QueryParameterValue.json("{\"class\" : {\"students\" : [{\"name\" : \"Jane\"}]}}");

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3656,6 +3656,26 @@ public class ITBigQueryTest {
   }
 
   @Test
+  public void testGeographyParameter() throws Exception {
+    // Issues a simple ST_DISTANCE using two geopoints, one being a named geography parameter.
+    String query = "SELECT ST_DISTANCE(ST_GEOGFROMTEXT(\"POINT(-122.335503 47.625536)\"), @geo < 3000 as within3k";
+    QueryParameterValue geoParameterValue = QueryParameterValue.geography("POINT(-122.3509153 47.6495389)");
+    QueryJobConfiguration config =
+        QueryJobConfiguration.newBuilder(query)
+            .setDefaultDataset(DatasetId.of(DATASET))
+            .setUseLegacySql(false)
+            .addNamedParameter("geo", geoParameterValue)
+            .build();
+    TableResult result = bigquery.query(config);
+    int rowCount = 0;
+    for (FieldValueList row : result.getValues()) {
+      rowCount++;
+      assertEquals(true, row.get(0).getBooleanValue());
+    }
+    assertEquals(1, rowCount);
+  }
+
+  @Test
   public void testListJobs() {
     Page<Job> jobs = bigquery.listJobs();
     for (Job job : jobs.getValues()) {

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3658,8 +3658,10 @@ public class ITBigQueryTest {
   @Test
   public void testGeographyParameter() throws Exception {
     // Issues a simple ST_DISTANCE using two geopoints, one being a named geography parameter.
-    String query = "SELECT ST_DISTANCE(ST_GEOGFROMTEXT(\"POINT(-122.335503 47.625536)\"), @geo < 3000 as within3k";
-    QueryParameterValue geoParameterValue = QueryParameterValue.geography("POINT(-122.3509153 47.6495389)");
+    String query =
+        "SELECT ST_DISTANCE(ST_GEOGFROMTEXT(\"POINT(-122.335503 47.625536)\"), @geo) < 3000 as within3k";
+    QueryParameterValue geoParameterValue =
+        QueryParameterValue.geography("POINT(-122.3509153 47.6495389)");
     QueryJobConfiguration config =
         QueryJobConfiguration.newBuilder(query)
             .setDefaultDataset(DatasetId.of(DATASET))


### PR DESCRIPTION
This PR adds support for binding a geography value directly as a query parameter, without the indirection of converting a string type to a geography time in the query body.

Related internal issue: b/238336732


