### PR TITLE
samples / fixing authorize dataset logic by updating source dataset acl 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.14.0'
+implementation 'com.google.cloud:google-cloud-bigquery:2.14.3'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.14.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.14.3"
 ```
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.0.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.14.5'
+implementation 'com.google.cloud:google-cloud-bigquery:2.14.6'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.14.5"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.14.6"
 ```
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.14.3'
+implementation 'com.google.cloud:google-cloud-bigquery:2.14.4'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.14.3"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.14.4"
 ```
 
 ## Authentication

--- a/samples/snippets/src/main/java/com/example/bigquery/AuthorizeDataset.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/AuthorizeDataset.java
@@ -58,12 +58,12 @@ public class AuthorizeDataset {
           new Acl.DatasetAclEntity(userDatasetId, targetTypes);
       sourceDatasetAcl.add(Acl.of(userDatasetAclEntity));
 
-      // update the user dataset with source dataset's ACL
-      Dataset updatedUserDataset =
-          userDataset.toBuilder().setAcl(sourceDatasetAcl).build().update();
+      // update the source dataset with user dataset's ACL
+      Dataset updatedSourceDataset =
+          sourceDataset.toBuilder().setAcl(sourceDatasetAcl).build().update();
 
       System.out.printf(
-          "Dataset %s updated with the added authorization\n", updatedUserDataset.getDatasetId());
+          "Dataset %s updated with the added authorization\n", updatedSourceDataset.getDatasetId());
 
     } catch (BigQueryException e) {
       System.out.println("Dataset Authorization failed due to error: \n" + e);

--- a/samples/snippets/src/main/java/com/example/bigquery/AuthorizeDataset.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/AuthorizeDataset.java
@@ -38,7 +38,7 @@ public class AuthorizeDataset {
         DatasetId.of(projectId, sourceDatasetName), DatasetId.of(projectId, userDatasetName));
   }
 
-  // This method will update userDataset's ACL with sourceDataset's ACL
+  // This method will update sourceDataset's ACL with userDataset's ACL
   public static void authorizeDataset(DatasetId sourceDatasetId, DatasetId userDatasetId) {
     try {
       // Initialize client that will be used to send requests. This client only needs to be created

--- a/samples/snippets/src/test/java/com/example/bigquery/AuthorizeDatasetIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/AuthorizeDatasetIT.java
@@ -80,6 +80,6 @@ public class AuthorizeDatasetIT {
   @Test
   public void testCreateDataset() {
     AuthorizeDataset.authorizeDataset(sourceDatasetId, userDatasetId);
-    assertThat(bout.toString()).contains(userDatasetId + " updated with the added authorization");
+    assertThat(bout.toString()).contains(sourceDatasetId + " updated with the added authorization");
   }
 }


### PR DESCRIPTION
Fixes#2188

Fixed the logic for authorizing a bigquery user dataset but updating the source dataset acl with that of the user dataset information. 
