### PR TITLE
feat: add fast query path support when empty jobId object is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.18.2'
+implementation 'com.google.cloud:google-cloud-bigquery:2.19.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.18.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.19.1"
 ```
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.1.3')
+implementation platform('com.google.cloud:libraries-bom:26.1.4')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.17.1'
+implementation 'com.google.cloud:google-cloud-bigquery:2.18.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.17.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.18.2"
 ```
 
 ## Authentication

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1389,7 +1389,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       // the job created by the query method will be in that location, even if the table to be
       // queried is in a different location. This may
       // cause the query to fail with "BigQueryException: Not found"
-      if(jobId.getLocation() != null) {
+      if (jobId.getLocation() != null) {
         content.setLocation(jobId.getLocation());
       }
       return queryRpc(projectId, content, options);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1384,6 +1384,12 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
     QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);
     if (requestInfo.isFastQuerySupported(jobId)) {
       String projectId = getOptions().getProjectId();
+      // Be careful when setting the projectID in JobId, if a projectID is specified in the JobId,
+      // the job created by the query method will use that project. This may
+      // cause the query to fail with "BigQueryException: Not found"
+      if(jobId.getProject() != null){
+        projectId = jobId.getProject();
+      }
       QueryRequest content = requestInfo.toPb();
       // Be careful when setting the location in JobId, if a location is specified in the JobId,
       // the job created by the query method will be in that location, even if the table to be
@@ -1392,6 +1398,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       if (jobId.getLocation() != null) {
         content.setLocation(jobId.getLocation());
       }
+
       return queryRpc(projectId, content, options);
     }
     return create(JobInfo.of(jobId, configuration), options).getQueryResults();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1294,7 +1294,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
     // If all parameters passed in configuration are supported by the query() method on the backend,
     // put on fast path
     QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);
-    if (requestInfo.isFastQuerySupported()) {
+    if (requestInfo.isFastQuerySupported(null)) {
       String projectId = getOptions().getProjectId();
       QueryRequest content = requestInfo.toPb();
       return queryRpc(projectId, content, options);
@@ -1379,6 +1379,14 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
   public TableResult query(QueryJobConfiguration configuration, JobId jobId, JobOption... options)
       throws InterruptedException, JobException {
     Job.checkNotDryRun(configuration, "query");
+    // If all parameters passed in configuration are supported by the query() method on the backend,
+    // put on fast path
+    QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);
+    if (requestInfo.isFastQuerySupported(jobId)) {
+      String projectId = getOptions().getProjectId();
+      QueryRequest content = requestInfo.toPb();
+      return queryRpc(projectId, content, options);
+    }
     return create(JobInfo.of(jobId, configuration), options).getQueryResults();
   }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1383,18 +1383,16 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
     // put on fast path
     QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);
     if (requestInfo.isFastQuerySupported(jobId)) {
-      String projectId = getOptions().getProjectId();
       // Be careful when setting the projectID in JobId, if a projectID is specified in the JobId,
-      // the job created by the query method will use that project. This may
-      // cause the query to fail with "BigQueryException: Not found"
-      if (jobId.getProject() != null) {
-        projectId = jobId.getProject();
-      }
+      // the job created by the query method will use that project. This may cause the query to
+      // fail with "Access denied" if the project do not have enough permissions to run the job.
+
+      String projectId = jobId.getProject() != null ? jobId.getProject() : getOptions().getProjectId();
       QueryRequest content = requestInfo.toPb();
       // Be careful when setting the location in JobId, if a location is specified in the JobId,
       // the job created by the query method will be in that location, even if the table to be
-      // queried is in a different location. This may
-      // cause the query to fail with "BigQueryException: Not found"
+      // queried is in a different location. This may cause the query to fail with
+      // "BigQueryException: Not found"
       if (jobId.getLocation() != null) {
         content.setLocation(jobId.getLocation());
       }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1387,7 +1387,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       // Be careful when setting the projectID in JobId, if a projectID is specified in the JobId,
       // the job created by the query method will use that project. This may
       // cause the query to fail with "BigQueryException: Not found"
-      if(jobId.getProject() != null){
+      if (jobId.getProject() != null) {
         projectId = jobId.getProject();
       }
       QueryRequest content = requestInfo.toPb();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1387,7 +1387,8 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       // the job created by the query method will use that project. This may cause the query to
       // fail with "Access denied" if the project do not have enough permissions to run the job.
 
-      String projectId = jobId.getProject() != null ? jobId.getProject() : getOptions().getProjectId();
+      String projectId =
+          jobId.getProject() != null ? jobId.getProject() : getOptions().getProjectId();
       QueryRequest content = requestInfo.toPb();
       // Be careful when setting the location in JobId, if a location is specified in the JobId,
       // the job created by the query method will be in that location, even if the table to be

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1385,6 +1385,13 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
     if (requestInfo.isFastQuerySupported(jobId)) {
       String projectId = getOptions().getProjectId();
       QueryRequest content = requestInfo.toPb();
+      // Be careful when setting the location in JobId, if a location is specified in the JobId,
+      // the job created by the query method will be in that location, even if the table to be
+      // queried is in a different location. This may
+      // cause the query to fail with "BigQueryException: Not found"
+      if(jobId.getLocation() != null) {
+        content.setLocation(jobId.getLocation());
+      }
       return queryRpc(projectId, content, options);
     }
     return create(JobInfo.of(jobId, configuration), options).getQueryResults();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -58,6 +58,13 @@ final class QueryRequestInfo {
   }
 
   boolean isFastQuerySupported(JobId jobId) {
+    boolean isJobId;
+    // Fast query path is not possible if jobId is specified
+    if( jobId != null) {
+      isJobId = jobId.getJob() == null;
+    } else {
+      isJobId = true;
+    }
     return config.getClustering() == null
         && config.getCreateDisposition() == null
         && config.getDestinationEncryptionConfiguration() == null
@@ -71,8 +78,7 @@ final class QueryRequestInfo {
         && config.getTimePartitioning() == null
         && config.getUserDefinedFunctions() == null
         && config.getWriteDisposition() == null
-        && jobId.getJob() == null
-        && jobId.getLocation() != null;
+        && isJobId;
   }
 
   QueryRequest toPb() {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -58,14 +58,11 @@ final class QueryRequestInfo {
   }
 
   boolean isFastQuerySupported(JobId jobId) {
-    boolean isJobIdFastQuerySupported;
     // Fast query path is not possible if job is specified in the JobID object
     // Respect Job field value in JobId specified by user.
     // Specifying it will force the query to take the slower path.
-    if (jobId != null) {
-      isJobIdFastQuerySupported = jobId.getJob() == null;
-    } else {
-      isJobIdFastQuerySupported = true;
+    if (jobId == null || jobId.getJob() != null) {
+      return false;
     }
     return config.getClustering() == null
         && config.getCreateDisposition() == null
@@ -79,8 +76,7 @@ final class QueryRequestInfo {
         && config.getTableDefinitions() == null
         && config.getTimePartitioning() == null
         && config.getUserDefinedFunctions() == null
-        && config.getWriteDisposition() == null
-        && isJobIdFastQuerySupported;
+        && config.getWriteDisposition() == null;
   }
 
   QueryRequest toPb() {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -58,14 +58,14 @@ final class QueryRequestInfo {
   }
 
   boolean isFastQuerySupported(JobId jobId) {
-    boolean isJobId;
-    // Fast query path is not possible if jobId is specified
-    // Respect both JobId and Location specified by user.
-    // Specifying either will force the query to take the slower path.
+    boolean isJobIdFastQuerySupported;
+    // Fast query path is not possible if job is specified in the JobID object
+    // Respect Job field value in JobId specified by user.
+    // Specifying it will force the query to take the slower path.
     if (jobId != null) {
-      isJobId = jobId.getJob() == null && jobId.getLocation() == null;
+      isJobIdFastQuerySupported = jobId.getJob() == null;
     } else {
-      isJobId = true;
+      isJobIdFastQuerySupported = true;
     }
     return config.getClustering() == null
         && config.getCreateDisposition() == null
@@ -80,7 +80,7 @@ final class QueryRequestInfo {
         && config.getTimePartitioning() == null
         && config.getUserDefinedFunctions() == null
         && config.getWriteDisposition() == null
-        && isJobId;
+        && isJobIdFastQuerySupported;
   }
 
   QueryRequest toPb() {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -60,8 +60,11 @@ final class QueryRequestInfo {
   boolean isFastQuerySupported(JobId jobId) {
     boolean isJobId;
     // Fast query path is not possible if jobId is specified
-    if (jobId != null) {
-      isJobId = jobId.getJob() == null;
+    // Respect both JobId and Location specified by user.
+    // Specifying either will force the query to take the slower path.
+    if( jobId != null) {
+      isJobId = jobId.getJob() == null
+          && jobId.getLocation() == null;
     } else {
       isJobId = true;
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -61,8 +61,10 @@ final class QueryRequestInfo {
     // Fast query path is not possible if job is specified in the JobID object
     // Respect Job field value in JobId specified by user.
     // Specifying it will force the query to take the slower path.
-    if (jobId == null || jobId.getJob() != null) {
-      return false;
+    if (jobId != null) {
+      if(jobId.getJob() != null){
+        return false;
+      }
     }
     return config.getClustering() == null
         && config.getCreateDisposition() == null

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -72,7 +72,7 @@ final class QueryRequestInfo {
         && config.getUserDefinedFunctions() == null
         && config.getWriteDisposition() == null
         && jobId.getJob() == null
-        && jobId.getLocation() !=null ;
+        && jobId.getLocation() != null;
   }
 
   QueryRequest toPb() {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -62,7 +62,7 @@ final class QueryRequestInfo {
     // Respect Job field value in JobId specified by user.
     // Specifying it will force the query to take the slower path.
     if (jobId != null) {
-      if(jobId.getJob() != null){
+      if (jobId.getJob() != null) {
         return false;
       }
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -57,7 +57,7 @@ final class QueryRequestInfo {
     this.useQueryCache = config.useQueryCache();
   }
 
-  boolean isFastQuerySupported() {
+  boolean isFastQuerySupported(JobId jobId) {
     return config.getClustering() == null
         && config.getCreateDisposition() == null
         && config.getDestinationEncryptionConfiguration() == null
@@ -70,7 +70,9 @@ final class QueryRequestInfo {
         && config.getTableDefinitions() == null
         && config.getTimePartitioning() == null
         && config.getUserDefinedFunctions() == null
-        && config.getWriteDisposition() == null;
+        && config.getWriteDisposition() == null
+        && jobId.getJob() == null
+        && jobId.getLocation() !=null ;
   }
 
   QueryRequest toPb() {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -62,9 +62,8 @@ final class QueryRequestInfo {
     // Fast query path is not possible if jobId is specified
     // Respect both JobId and Location specified by user.
     // Specifying either will force the query to take the slower path.
-    if( jobId != null) {
-      isJobId = jobId.getJob() == null
-          && jobId.getLocation() == null;
+    if (jobId != null) {
+      isJobId = jobId.getJob() == null && jobId.getLocation() == null;
     } else {
       isJobId = true;
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -60,7 +60,7 @@ final class QueryRequestInfo {
   boolean isFastQuerySupported(JobId jobId) {
     boolean isJobId;
     // Fast query path is not possible if jobId is specified
-    if( jobId != null) {
+    if (jobId != null) {
       isJobId = jobId.getJob() == null;
     } else {
       isJobId = true;

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
@@ -150,8 +150,12 @@ public class QueryRequestInfoTest {
 
   @Test
   public void testIsFastQuerySupported() {
-    assertEquals(false, REQUEST_INFO.isFastQuerySupported());
-    assertEquals(true, REQUEST_INFO_SUPPORTED.isFastQuerySupported());
+    JobId jobIdSupported = JobId.newBuilder().setLocation("US").build();
+    JobId jobIdNotSupported = JobId.newBuilder().setJob("random-job-id").build();
+    assertEquals(false, REQUEST_INFO.isFastQuerySupported(jobIdSupported));
+    assertEquals(true, REQUEST_INFO_SUPPORTED.isFastQuerySupported(jobIdSupported));
+    assertEquals(false, REQUEST_INFO.isFastQuerySupported(jobIdNotSupported));
+    assertEquals(false, REQUEST_INFO_SUPPORTED.isFastQuerySupported(jobIdNotSupported));
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -534,7 +534,8 @@ public class ITBigQueryTest {
   private static final TableId TABLE_ID = TableId.of(DATASET, "testing_table");
   private static final TableId TABLE_ID_DDL = TableId.of(DATASET, "ddl_testing_table");
   private static final TableId TABLE_ID_FASTQUERY = TableId.of(DATASET, "fastquery_testing_table");
-  private static final TableId TABLE_ID_FASTQUERY_UK = TableId.of(UK_DATASET, "fastquery_testing_table");
+  private static final TableId TABLE_ID_FASTQUERY_UK =
+      TableId.of(UK_DATASET, "fastquery_testing_table");
   private static final TableId TABLE_ID_LARGE = TableId.of(DATASET, "large_data_testing_table");
   private static final TableId TABLE_ID_FASTQUERY_BQ_RESULTSET =
       TableId.of(DATASET, "fastquery_testing_bq_resultset");
@@ -677,7 +678,6 @@ public class ITBigQueryTest {
   private static final String PUBLIC_PROJECT = "bigquery-public-data";
   private static final String PUBLIC_DATASET = "census_bureau_international";
 
-
   private static BigQuery bigquery;
   private static Storage storage;
 
@@ -733,7 +733,6 @@ public class ITBigQueryTest {
     assertNull(job.getStatus().getError());
     LoadJobConfiguration loadJobConfiguration = job.getConfiguration();
     assertEquals(labels, loadJobConfiguration.getLabels());
-
 
     LoadJobConfiguration configurationFastQuery =
         LoadJobConfiguration.newBuilder(
@@ -3276,17 +3275,24 @@ public class ITBigQueryTest {
   @Test
   public void testFastSQLQueryWithJobId() throws InterruptedException {
     DatasetInfo infoUK =
-        DatasetInfo.newBuilder(UK_DATASET).setDescription(DESCRIPTION).setLocation("europe-west1").setLabels(LABELS).build();
+        DatasetInfo.newBuilder(UK_DATASET)
+            .setDescription(DESCRIPTION)
+            .setLocation("europe-west1")
+            .setLabels(LABELS)
+            .build();
     bigquery.create(infoUK);
 
     TableDefinition tableDefinition = StandardTableDefinition.of(SIMPLE_SCHEMA);
     TableInfo tableInfo = TableInfo.newBuilder(TABLE_ID_FASTQUERY_UK, tableDefinition).build();
     bigquery.create(tableInfo);
 
-    String insert = "INSERT " + UK_DATASET  + "." + TABLE_ID_FASTQUERY_UK.getTable() + " VALUES('Anna');";
+    String insert =
+        "INSERT " + UK_DATASET + "." + TABLE_ID_FASTQUERY_UK.getTable() + " VALUES('Anna');";
 
     QueryJobConfiguration config =
-        QueryJobConfiguration.newBuilder(insert).setDefaultDataset(DatasetId.of(UK_DATASET)).build();
+        QueryJobConfiguration.newBuilder(insert)
+            .setDefaultDataset(DatasetId.of(UK_DATASET))
+            .build();
     TableResult result = bigquery.query(config);
     assertEquals(SIMPLE_SCHEMA, result.getSchema());
     assertEquals(1, result.getTotalRows());
@@ -3301,20 +3307,18 @@ public class ITBigQueryTest {
     }
     // With incorrect location in jobid
     // The job will be created with the specified(incorrect) location
-    String query =
-        "SELECT StringField FROM " + TABLE_ID_FASTQUERY_UK.getTable();
+    String query = "SELECT StringField FROM " + TABLE_ID_FASTQUERY_UK.getTable();
     JobId jobIdWithLocation = JobId.newBuilder().setLocation("us-west1").build();
     QueryJobConfiguration configSelect =
         QueryJobConfiguration.newBuilder(query).setDefaultDataset(DatasetId.of(UK_DATASET)).build();
     try {
       bigquery.query(configSelect, jobIdWithLocation);
-    } catch (BigQueryException exception){
+    } catch (BigQueryException exception) {
       assertTrue(exception.getMessage().contains("Not found"));
       assertEquals(BigQueryException.class, exception.getClass());
-
     }
 
-    //WithoutJobId in location, the query job defaults to the location of the dataset
+    // WithoutJobId in location, the query job defaults to the location of the dataset
     JobId jobIdNoLocation = JobId.newBuilder().build();
     QueryJobConfiguration configNoLocation =
         QueryJobConfiguration.newBuilder(query).setDefaultDataset(DatasetId.of(UK_DATASET)).build();


### PR DESCRIPTION
Currently, if a jobID object is passed to the query method, it goes through the slow query path always. This PR allows user to set the location and project ID of the job being created with the JobID object AND take the fast query path if all the conditions for fast query path are met.

Note: If the user specifies the job id string in the job id object being supplied to the query method, the workflow will default to the slow query path and use the job id specified.