### PR TITLE
chore(deps): update ghcr.io/graalvm/graalvm-ce docker tag to v22.3.2

### DIFF
--- a/.kokoro/continuous/graalvm-native-17.cfg
+++ b/.kokoro/continuous/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/continuous/graalvm-native.cfg
+++ b/.kokoro/continuous/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 env_vars: {


### PR DESCRIPTION
Native Image checks run as continuous jobs in bigquery. 
