### PR TITLE
Don't throw exception in AbstractJdbcResultSet.close method

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/AbstractJdbcResultSet.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/AbstractJdbcResultSet.java
@@ -33,12 +33,6 @@ abstract class AbstractJdbcResultSet implements ResultSet {
   }
 
   @Override
-  public void close() throws SQLException {
-    // TODO: Implement the logic
-    throw new RuntimeException("Not implemented");
-  }
-
-  @Override
   public boolean wasNull() throws SQLException {
     // TODO: Implement the logic
     throw new RuntimeException("Not implemented");

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryResultImpl.java
@@ -141,6 +141,11 @@ public class BigQueryResultImpl<T> implements BigQueryResult<T> {
       }
     }
 
+    @Override
+    public void close() throws SQLException {
+      // TODO: Implement the logic
+    }
+
     private boolean isEndOfStream(T cursor) {
       return cursor instanceof ConnectionImpl.EndOfFieldValueList;
     }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3013,6 +3013,7 @@ public class ITBigQueryTest {
       ++cnt;
     }
     assertEquals(300000, cnt); // total 300000 rows should be read
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3042,6 +3043,7 @@ public class ITBigQueryTest {
       ++cnt;
     }
     assertEquals(300000, cnt); // total 300000 rows should be read
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3102,6 +3104,7 @@ public class ITBigQueryTest {
     assertEquals(3, (integerArrayFieldValue.get(2).getNumericValue()).intValue());
 
     assertFalse(rs.next()); // no 3rd row in the table
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3128,6 +3131,7 @@ public class ITBigQueryTest {
     assertTrue(cnt < 100000); // Extra records are still read even after canceling, as
     // the backgrounds threads are still active while the interrupt occurs and the
     // buffer and pageCache are cleared
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3154,6 +3158,7 @@ public class ITBigQueryTest {
       ++cnt;
     }
     assertEquals(300000, cnt); // total 300000 rows should be read
+    rs.close();  // assert close method does not throw an exception
   }
 
   // @Test - Temporarily disabling till https://github.com/googleapis/gax-java/issues/1712 or
@@ -3192,6 +3197,7 @@ public class ITBigQueryTest {
     }
     assertEquals(300000, cnt); // total 300000 rows should be read
     connection.close();
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3233,6 +3239,7 @@ public class ITBigQueryTest {
     }
     assertEquals(300000, cnt); // total 300000 rows should be read
     connection.close();
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3383,6 +3390,7 @@ public class ITBigQueryTest {
       }
       assertEquals(300000, cnt); // total 300000 rows should be read
       assertTrue(connection.close()); // check if connection closed
+      rs.close();  // assert close method does not throw an exception
       closeCnt++;
     }
     assertEquals(
@@ -3452,6 +3460,7 @@ public class ITBigQueryTest {
             (integerArrayFieldValue.get(2).getNumericValue()).intValue(),
             (integerArrayFieldValueColInd.get(2).getNumericValue()).intValue());
       }
+      rs.close();  // assert close method does not throw an exception
     }
   }
 
@@ -3486,6 +3495,7 @@ public class ITBigQueryTest {
     assertEquals("Vancouver", addressFieldValue.get(0).getStringValue());
     assertEquals(5, addressFieldValue.get(1).getLongValue());
     assertFalse(rs.next()); // only 1 row of data
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3512,6 +3522,7 @@ public class ITBigQueryTest {
     assertEquals(rs.getString("city"), rs.getObject(0));
     assertEquals("Vancouver", cityFieldValue);
     assertFalse(rs.next()); // only 1 row of data
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3535,6 +3546,7 @@ public class ITBigQueryTest {
     assertEquals(1, arrayFieldValue.get(0).getLongValue());
     assertEquals(2, arrayFieldValue.get(1).getLongValue());
     assertEquals(3, arrayFieldValue.get(2).getLongValue());
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -3574,6 +3586,7 @@ public class ITBigQueryTest {
     assertEquals(Attribute.RECORD, arrayOfStructFieldValue.get(1).getAttribute());
     assertEquals("Boston", arrayOfStructFieldValue.get(1).getRecordValue().get(0).getStringValue());
     assertEquals(10, arrayOfStructFieldValue.get(1).getRecordValue().get(1).getLongValue());
+    rs.close();  // assert close method does not throw an exception
   }
 
   /* TODO(prasmish): replicate the entire test case for executeSelect */

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITNightlyBigQueryTest.java
@@ -272,6 +272,7 @@ public class ITNightlyBigQueryTest {
     }
     assertEquals(LIMIT_RECS, cnt); // all the records were retrieved
     connection.close();
+    rs.close();  // assert close method does not throw an exception
   }
 
   /*
@@ -336,6 +337,7 @@ public class ITNightlyBigQueryTest {
     }
     assertEquals(LIMIT_RECS, cnt); // all the records were retrieved
     assertTrue(connection.close());
+    rs.close();  // assert close method does not throw an exception
   }
 
   /*
@@ -361,6 +363,7 @@ public class ITNightlyBigQueryTest {
     // to be retrieved
     // as a number of records should have been already buffered. less than
     // LIMIT_RECS should be retrieved
+    rs.close();  // assert close method does not throw an exception
   }
 
   @Test
@@ -449,6 +452,7 @@ public class ITNightlyBigQueryTest {
       ++cnt;
     }
     connection.close();
+    rs.close();  // assert close method does not throw an exception
     totalCnt += cnt;
     assertEquals(MULTI_LIMIT_RECS * 2, totalCnt);
   }
@@ -484,6 +488,7 @@ public class ITNightlyBigQueryTest {
       ++cnt;
     }
     connection.close();
+    rs.close();  // assert close method does not throw an exception
     assertEquals(MULTI_LIMIT_RECS, cnt);
   }
 
@@ -537,13 +542,14 @@ public class ITNightlyBigQueryTest {
 
   // this iterated through all the rows (just reads the title column)
   private Long getResultHashWiki(BigQueryResult bigQueryResultSet) throws SQLException {
-    ResultSet rs = bigQueryResultSet.getResultSet();
-    long hash = 0L;
-    System.out.print("\n Running");
-    while (rs.next()) {
-      hash += rs.getString("title") == null ? 0 : rs.getString("title").hashCode();
+    try (ResultSet rs = bigQueryResultSet.getResultSet()) {
+      long hash = 0L;
+      System.out.print("\n Running");
+      while (rs.next()) {
+        hash += rs.getString("title") == null ? 0 : rs.getString("title").hashCode();
+      }
+      return hash;
     }
-    return hash;
   }
 
   // asserts the value of each row


### PR DESCRIPTION
Fixes #2832 ☕️