### PR TITLE
feat: add support for converting interval fields to threeten PeriodDuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.19.0</version>
+      <version>26.20.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -53,7 +53,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.19.0')
+implementation platform('com.google.cloud:libraries-bom:26.21.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.31.1'
+implementation 'com.google.cloud:google-cloud-bigquery:2.31.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.31.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.31.2"
 ```
 <!-- {x-version-update-end} -->
 
@@ -351,7 +351,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquery/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquery.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.31.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.31.2
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.31.0'
+implementation 'com.google.cloud:google-cloud-bigquery:2.31.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.31.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.31.1"
 ```
 <!-- {x-version-update-end} -->
 
@@ -351,7 +351,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquery/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquery.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.31.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.31.1
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
@@ -27,10 +27,16 @@ import com.google.common.io.BaseEncoding;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.Period;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.threeten.extra.PeriodDuration;
 
 /**
  * Google BigQuery Table Field Value class. Objects of this class represent values of a BigQuery
@@ -238,6 +244,28 @@ public class FieldValue implements Serializable {
   }
 
   /**
+   * Returns this field's value as a {@link org.threeten.extra.PeriodDuration}. This method should
+   * be used if the corresponding field has {@link StandardSQLTypeName#INTERVAL} type, or if it is a
+   * legal canonical format "[sign]Y-M [sign]D [sign]H:M:S[.F]", e.g. "123-7 -19 0:24:12.000006" or
+   * ISO 8601.
+   *
+   * @throws ClassCastException if the field is not a primitive type
+   * @throws NullPointerException if {@link #isNull()} returns {@code true}
+   * @throws IllegalArgumentException if the field cannot be converted to a legal interval
+   */
+  @SuppressWarnings("unchecked")
+  public PeriodDuration getPeriodDuration() {
+    checkNotNull(value);
+    try {
+      // Try parsing from ISO 8601
+      return PeriodDuration.parse(getStringValue());
+    } catch (DateTimeParseException dateTimeParseException) {
+      // Try parsing from canonical interval format
+      return parseCanonicalInterval(getStringValue());
+    }
+  }
+
+  /**
    * Returns this field's value as a {@link FieldValueList} instance. This method should only be
    * used if the corresponding field has {@link LegacySQLTypeName#RECORD} type (i.e. {@link
    * #getAttribute()} is {@link Attribute#RECORD}).
@@ -324,5 +352,64 @@ public class FieldValue implements Serializable {
       }
     }
     throw new IllegalArgumentException("Unexpected table cell format");
+  }
+
+  /**
+   * Parse interval in canonical format and create instance of {@code FieldValue}.
+   *
+   * <p>The parameter {@code interval} should be an interval in the canonical format: "[sign]Y-M
+   * [sign]D [sign]H:M:S[.F]". More details <a href=
+   * "https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#canonical_format_3">
+   * here</a>
+   *
+   * @throws IllegalArgumentException if the {@code interval} is not a valid interval
+   */
+  static PeriodDuration parseCanonicalInterval(String interval) throws IllegalArgumentException {
+    // Pattern is [sign]Y-M [sign]D [sign]H:M:S[.F]
+    Pattern pattern =
+        Pattern.compile(
+            "(?<sign1>[+-])?(?<year>\\d+)-(?<month>\\d+) (?<sign2>[-|+])?(?<day>\\d+) (?<sign3>[-|+])?(?<hours>\\d+):(?<minutes>\\d+):(?<seconds>\\d+)(\\.(?<fraction>\\d+))?");
+    Matcher matcher = pattern.matcher(interval);
+    if (!matcher.find()) {
+      throw new IllegalArgumentException();
+    }
+    String sign1 = matcher.group("sign1");
+    String year = matcher.group("year");
+    String month = matcher.group("month");
+    String sign2 = matcher.group("sign2");
+    String day = matcher.group("day");
+    String sign3 = matcher.group("sign3");
+    String hours = matcher.group("hours");
+    String minutes = matcher.group("minutes");
+    String seconds = matcher.group("seconds");
+    String fraction = matcher.group("fraction");
+
+    int yearInt = Integer.parseInt(year);
+    int monthInt = Integer.parseInt(month);
+    if (Objects.equals(sign1, "-")) {
+      yearInt *= -1;
+      monthInt *= -1;
+    }
+
+    int dayInt = Integer.parseInt(day);
+    if (Objects.equals(sign2, "-")) {
+      dayInt *= -1;
+    }
+    if (sign3 == null) {
+      sign3 = "";
+    }
+
+    String durationString =
+        sign3
+            + "PT"
+            + hours
+            + "H"
+            + minutes
+            + "M"
+            + seconds
+            + (fraction == null ? "" : "." + fraction)
+            + "S";
+
+    return PeriodDuration.of(Period.of(yearInt, monthInt, dayInt), Duration.parse(durationString));
   }
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
@@ -355,7 +355,7 @@ public class FieldValue implements Serializable {
   }
 
   /**
-   * Parse interval in canonical format and create instance of {@code FieldValue}.
+   * Parse interval in canonical format and create instance of {@code PeriodDuration}.
    *
    * <p>The parameter {@code interval} should be an interval in the canonical format: "[sign]Y-M
    * [sign]D [sign]H:M:S[.F]". More details <a href=

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1228,8 +1228,11 @@ public class ITBigQueryTest {
               .build();
       TableResult result = bigquery.query(queryJobConfiguration);
       assertNotNull(result.getJobId());
+      PeriodDuration periodDuration =
+          PeriodDuration.of(Period.of(125, 7, -19), java.time.Duration.parse("PT24M12.000006S"));
       for (FieldValueList values : result.iterateAll()) {
         assertEquals("125-7 -19 0:24:12.000006", values.get(0).getValue());
+        assertEquals(periodDuration, values.get(0).getPeriodDuration());
       }
     } finally {
       assertTrue(bigquery.delete(tableId));


### PR DESCRIPTION
Add support for converting BigQuery interval type to threeten PeriodDuration, information about the canonical interval form can be found [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#canonical_format_3). Parsing logic was referenced from [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/interval_functions#extract).

Fixes #1849 ☕️
