### PR TITLE
feat: add support for preview features

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.23.0')
+implementation platform('com.google.cloud:libraries-bom:26.24.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.33.1'
+implementation 'com.google.cloud:google-cloud-bigquery:2.33.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.33.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.33.2"
 ```
 <!-- {x-version-update-end} -->
 
@@ -351,7 +351,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquery/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquery.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.33.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.33.2
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -1596,6 +1596,16 @@ public interface BigQuery extends Service<BigQueryOptions> {
    * }
    * </pre>
    *
+   * This method supports query-related preview features via environmental variables (enabled by
+   * setting the {@code QUERY_PREVIEW_ENABLED} environment variable to "TRUE"). Specifically, this
+   * method supports:
+   *
+   * <ul>
+   *   <li><b>Stateless queries</b>: query execution without corresponding job metadata
+   * </ul>
+   *
+   * The behaviour of these preview features is controlled by the bigquery service as well
+   *
    * @throws BigQueryException upon failure
    * @throws InterruptedException if the current thread gets interrupted while waiting for the query
    *     to complete

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -41,6 +41,7 @@ import com.google.cloud.RetryHelper;
 import com.google.cloud.RetryHelper.RetryHelperException;
 import com.google.cloud.Tuple;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import com.google.cloud.bigquery.QueryJobConfiguration.JobCreationMode;
 import com.google.cloud.bigquery.spi.v2.BigQueryRpc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -1324,6 +1325,14 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       throws InterruptedException, JobException {
     Job.checkNotDryRun(configuration, "query");
 
+    if (getOptions().isQueryPreviewEnabled()) {
+      configuration =
+          configuration
+              .toBuilder()
+              .setJobCreationMode(JobCreationMode.JOB_CREATION_OPTIONAL)
+              .build();
+    }
+
     // If all parameters passed in configuration are supported by the query() method on the backend,
     // put on fast path
     QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);
@@ -1416,6 +1425,15 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
   public TableResult query(QueryJobConfiguration configuration, JobId jobId, JobOption... options)
       throws InterruptedException, JobException {
     Job.checkNotDryRun(configuration, "query");
+
+    if (getOptions().isQueryPreviewEnabled()) {
+      configuration =
+          configuration
+              .toBuilder()
+              .setJobCreationMode(JobCreationMode.JOB_CREATION_OPTIONAL)
+              .build();
+    }
+
     // If all parameters passed in configuration are supported by the query() method on the backend,
     // put on fast path
     QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1426,14 +1426,6 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       throws InterruptedException, JobException {
     Job.checkNotDryRun(configuration, "query");
 
-    if (getOptions().isQueryPreviewEnabled()) {
-      configuration =
-          configuration
-              .toBuilder()
-              .setJobCreationMode(JobCreationMode.JOB_CREATION_OPTIONAL)
-              .build();
-    }
-
     // If all parameters passed in configuration are supported by the query() method on the backend,
     // put on fast path
     QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.spi.BigQueryRpcFactory;
 import com.google.cloud.bigquery.spi.v2.BigQueryRpc;
 import com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc;
 import com.google.cloud.http.HttpTransportOptions;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
@@ -37,6 +38,7 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
   private final String location;
   // set the option ThrowNotFound when you want to throw the exception when the value not found
   private boolean setThrowNotFound;
+  private String queryPreviewEnabled = System.getenv("QUERY_PREVIEW_ENABLED");
 
   public static class DefaultBigQueryFactory implements BigQueryFactory {
 
@@ -130,8 +132,17 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
     return location;
   }
 
+  public boolean isQueryPreviewEnabled() {
+    return queryPreviewEnabled != null && queryPreviewEnabled.equalsIgnoreCase("TRUE");
+  }
+
   public void setThrowNotFound(boolean setThrowNotFound) {
     this.setThrowNotFound = setThrowNotFound;
+  }
+
+  @VisibleForTesting
+  public void setQueryPreviewEnabled(String queryPreviewEnabled) {
+    this.queryPreviewEnabled = queryPreviewEnabled;
   }
 
   public boolean getThrowNotFound() {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -95,9 +95,18 @@ public final class QueryJobConfiguration extends JobConfiguration {
     BATCH
   }
 
-  public enum JobCreationMode {
+  /** Job Creation Mode provides different options on job creation. */
+  enum JobCreationMode {
+    /** Unspecified JobCreationMode, defaults to JOB_CREATION_REQUIRED. */
     JOB_CREATION_MODE_UNSPECIFIED,
+    /** Default. Job creation is always required. */
     JOB_CREATION_REQUIRED,
+    /**
+     * Job creation is optional. Returning immediate results is prioritized. BigQuery will
+     * automatically determine if a Job needs to be created. The conditions under which BigQuery can
+     * decide to not create a Job are subject to change. If Job creation is required,
+     * JOB_CREATION_REQUIRED mode should be used, which is the default.
+     */
     JOB_CREATION_OPTIONAL,
   }
 
@@ -275,10 +284,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
             Lists.transform(
                 queryConfigurationPb.getConnectionProperties(),
                 ConnectionProperty.FROM_PB_FUNCTION);
-      }
-      if (queryConfigurationPb.get("jobCreationMode") != null) {
-        jobCreationMode =
-            JobCreationMode.valueOf((String) queryConfigurationPb.get("jobCreationMode"));
       }
     }
 
@@ -672,7 +677,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
      * Provides different options on job creation. If not specified the job creation mode is assumed
      * to be {@link JobCreationMode#JOB_CREATION_REQUIRED}.
      */
-    public Builder setJobCreationMode(JobCreationMode jobCreationMode) {
+    Builder setJobCreationMode(JobCreationMode jobCreationMode) {
       this.jobCreationMode = jobCreationMode;
       return this;
     }
@@ -721,10 +726,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
     this.rangePartitioning = builder.rangePartitioning;
     this.connectionProperties = builder.connectionProperties;
     this.maxResults = builder.maxResults;
-    this.jobCreationMode =
-        builder.jobCreationMode != null
-            ? builder.jobCreationMode
-            : JobCreationMode.JOB_CREATION_MODE_UNSPECIFIED;
+    this.jobCreationMode = builder.jobCreationMode;
   }
 
   /**
@@ -937,7 +939,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
   }
 
   /** Returns the job creation mode. */
-  public JobCreationMode getJobCreationMode() {
+  JobCreationMode getJobCreationMode() {
     return jobCreationMode;
   }
 
@@ -1014,8 +1016,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
         jobTimeoutMs,
         labels,
         rangePartitioning,
-        connectionProperties,
-        jobCreationMode);
+        connectionProperties);
   }
 
   @Override

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -73,6 +73,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
   private final List<ConnectionProperty> connectionProperties;
   // maxResults is only used for fast query path
   private final Long maxResults;
+  private final JobCreationMode jobCreationMode;
 
   /**
    * Priority levels for a query. If not specified the priority is assumed to be {@link
@@ -92,6 +93,12 @@ public final class QueryJobConfiguration extends JobConfiguration {
      * Priority#INTERACTIVE}.
      */
     BATCH
+  }
+
+  public enum JobCreationMode {
+    JOB_CREATION_MODE_UNSPECIFIED,
+    JOB_CREATION_REQUIRED,
+    JOB_CREATION_OPTIONAL,
   }
 
   public static final class Builder
@@ -125,6 +132,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
     private RangePartitioning rangePartitioning;
     private List<ConnectionProperty> connectionProperties;
     private Long maxResults;
+    private JobCreationMode jobCreationMode;
 
     private Builder() {
       super(Type.QUERY);
@@ -160,6 +168,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
       this.rangePartitioning = jobConfiguration.rangePartitioning;
       this.connectionProperties = jobConfiguration.connectionProperties;
       this.maxResults = jobConfiguration.maxResults;
+      this.jobCreationMode = jobConfiguration.jobCreationMode;
     }
 
     private Builder(com.google.api.services.bigquery.model.JobConfiguration configurationPb) {
@@ -266,6 +275,10 @@ public final class QueryJobConfiguration extends JobConfiguration {
             Lists.transform(
                 queryConfigurationPb.getConnectionProperties(),
                 ConnectionProperty.FROM_PB_FUNCTION);
+      }
+      if (queryConfigurationPb.get("jobCreationMode") != null) {
+        jobCreationMode =
+            JobCreationMode.valueOf((String) queryConfigurationPb.get("jobCreationMode"));
       }
     }
 
@@ -655,6 +668,15 @@ public final class QueryJobConfiguration extends JobConfiguration {
       return this;
     }
 
+    /**
+     * Provides different options on job creation. If not specified the job creation mode is assumed
+     * to be {@link JobCreationMode#JOB_CREATION_REQUIRED}.
+     */
+    public Builder setJobCreationMode(JobCreationMode jobCreationMode) {
+      this.jobCreationMode = jobCreationMode;
+      return this;
+    }
+
     public QueryJobConfiguration build() {
       return new QueryJobConfiguration(this);
     }
@@ -699,6 +721,10 @@ public final class QueryJobConfiguration extends JobConfiguration {
     this.rangePartitioning = builder.rangePartitioning;
     this.connectionProperties = builder.connectionProperties;
     this.maxResults = builder.maxResults;
+    this.jobCreationMode =
+        builder.jobCreationMode != null
+            ? builder.jobCreationMode
+            : JobCreationMode.JOB_CREATION_MODE_UNSPECIFIED;
   }
 
   /**
@@ -910,6 +936,11 @@ public final class QueryJobConfiguration extends JobConfiguration {
     return maxResults;
   }
 
+  /** Returns the job creation mode. */
+  public JobCreationMode getJobCreationMode() {
+    return jobCreationMode;
+  }
+
   @Override
   public Builder toBuilder() {
     return new Builder(this);
@@ -944,7 +975,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
         .add("jobTimeoutMs", jobTimeoutMs)
         .add("labels", labels)
         .add("rangePartitioning", rangePartitioning)
-        .add("connectionProperties", connectionProperties);
+        .add("connectionProperties", connectionProperties)
+        .add("jobCreationMode", jobCreationMode);
   }
 
   @Override
@@ -982,7 +1014,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
         jobTimeoutMs,
         labels,
         rangePartitioning,
-        connectionProperties);
+        connectionProperties,
+        jobCreationMode);
   }
 
   @Override

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -119,7 +119,9 @@ final class QueryRequestInfo {
     if (useQueryCache != null) {
       request.setUseQueryCache(useQueryCache);
     }
-    request.set("jobCreationMode", jobCreationMode.toString());
+    if (jobCreationMode != null) {
+      request.setJobCreationMode(jobCreationMode.toString());
+    }
     return request;
   }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery;
 
 import com.google.api.services.bigquery.model.QueryParameter;
 import com.google.api.services.bigquery.model.QueryRequest;
+import com.google.cloud.bigquery.QueryJobConfiguration.JobCreationMode;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
@@ -40,6 +41,7 @@ final class QueryRequestInfo {
   private final Boolean createSession;
   private final Boolean useQueryCache;
   private final Boolean useLegacySql;
+  private final JobCreationMode jobCreationMode;
 
   QueryRequestInfo(QueryJobConfiguration config) {
     this.config = config;
@@ -55,6 +57,7 @@ final class QueryRequestInfo {
     this.createSession = config.createSession();
     this.useLegacySql = config.useLegacySql();
     this.useQueryCache = config.useQueryCache();
+    this.jobCreationMode = config.getJobCreationMode();
   }
 
   boolean isFastQuerySupported(JobId jobId) {
@@ -116,6 +119,7 @@ final class QueryRequestInfo {
     if (useQueryCache != null) {
       request.setUseQueryCache(useQueryCache);
     }
+    request.set("jobCreationMode", jobCreationMode.toString());
     return request;
   }
 
@@ -134,6 +138,7 @@ final class QueryRequestInfo {
         .add("createSession", createSession)
         .add("useQueryCache", useQueryCache)
         .add("useLegacySql", useLegacySql)
+        .add("jobCreationMode", jobCreationMode)
         .toString();
   }
 
@@ -151,7 +156,8 @@ final class QueryRequestInfo {
         requestId,
         createSession,
         useQueryCache,
-        useLegacySql);
+        useLegacySql,
+        jobCreationMode);
   }
 
   @Override

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import com.google.cloud.bigquery.JobInfo.CreateDisposition;
 import com.google.cloud.bigquery.JobInfo.SchemaUpdateOption;
 import com.google.cloud.bigquery.JobInfo.WriteDisposition;
+import com.google.cloud.bigquery.QueryJobConfiguration.JobCreationMode;
 import com.google.cloud.bigquery.QueryJobConfiguration.Priority;
 import com.google.cloud.bigquery.TimePartitioning.Type;
 import com.google.common.collect.ImmutableList;
@@ -110,6 +111,7 @@ public class QueryJobConfigurationTest {
   private static final Map<String, QueryParameterValue> NAME_PARAMETER =
       ImmutableMap.of("string", STRING_PARAMETER, "timestamp", TIMESTAMP_PARAMETER);
   private static final String PARAMETER_MODE = "POSITIONAL";
+  private static final JobCreationMode JOB_CREATION_MODE = JobCreationMode.JOB_CREATION_OPTIONAL;
   private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION =
       QueryJobConfiguration.newBuilder(QUERY)
           .setUseQueryCache(USE_QUERY_CACHE)
@@ -150,6 +152,8 @@ public class QueryJobConfigurationTest {
           .setPositionalParameters(ImmutableList.<QueryParameterValue>of())
           .setNamedParameters(NAME_PARAMETER)
           .build();
+  private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION_SET_JOB_CREATION_MODE =
+      QUERY_JOB_CONFIGURATION.toBuilder().setJobCreationMode(JOB_CREATION_MODE).build();
 
   @Test
   public void testToBuilder() {
@@ -228,6 +232,13 @@ public class QueryJobConfigurationTest {
     compareQueryJobConfiguration(
         QUERY_JOB_CONFIGURATION_SET_NAME_PARAMETER,
         QUERY_JOB_CONFIGURATION_SET_NAME_PARAMETER.toBuilder().build());
+  }
+
+  @Test
+  public void testJobCreationMode() {
+    compareQueryJobConfiguration(
+        QUERY_JOB_CONFIGURATION_SET_JOB_CREATION_MODE,
+        QUERY_JOB_CONFIGURATION_SET_JOB_CREATION_MODE.toBuilder().build());
   }
 
   private void compareQueryJobConfiguration(

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
@@ -23,6 +23,7 @@ import com.google.api.services.bigquery.model.QueryRequest;
 import com.google.cloud.bigquery.JobInfo.CreateDisposition;
 import com.google.cloud.bigquery.JobInfo.SchemaUpdateOption;
 import com.google.cloud.bigquery.JobInfo.WriteDisposition;
+import com.google.cloud.bigquery.QueryJobConfiguration.JobCreationMode;
 import com.google.cloud.bigquery.QueryJobConfiguration.Priority;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -105,6 +106,8 @@ public class QueryRequestInfoTest {
       ImmutableList.of(STRING_PARAMETER, TIMESTAMP_PARAMETER);
   private static final Map<String, QueryParameterValue> NAME_PARAMETER =
       ImmutableMap.of("string", STRING_PARAMETER, "timestamp", TIMESTAMP_PARAMETER);
+  private static final JobCreationMode jobCreationModeRequired =
+      JobCreationMode.JOB_CREATION_REQUIRED;
   private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION =
       QueryJobConfiguration.newBuilder(QUERY)
           .setUseQueryCache(USE_QUERY_CACHE)
@@ -131,6 +134,7 @@ public class QueryRequestInfoTest {
           .setConnectionProperties(CONNECTION_PROPERTIES)
           .setPositionalParameters(POSITIONAL_PARAMETER)
           .setMaxResults(100L)
+          .setJobCreationMode(jobCreationModeRequired)
           .build();
   QueryRequestInfo REQUEST_INFO = new QueryRequestInfo(QUERY_JOB_CONFIGURATION);
   private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION_SUPPORTED =
@@ -194,5 +198,6 @@ public class QueryRequestInfoTest {
     assertEquals(expectedQueryReq.getCreateSession(), actualQueryReq.getCreateSession());
     assertEquals(expectedQueryReq.getUseQueryCache(), actualQueryReq.getUseQueryCache());
     assertEquals(expectedQueryReq.getUseLegacySql(), actualQueryReq.getUseLegacySql());
+    assertEquals(expectedQueryReq.get("jobCreationMode"), actualQueryReq.get("jobCreationMode"));
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -103,6 +103,7 @@ import com.google.cloud.bigquery.ParquetOptions;
 import com.google.cloud.bigquery.PolicyTags;
 import com.google.cloud.bigquery.PrimaryKey;
 import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryJobConfiguration.JobCreationMode;
 import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.cloud.bigquery.RangePartitioning;
 import com.google.cloud.bigquery.Routine;
@@ -6164,5 +6165,16 @@ public class ITBigQueryTest {
         fail("Already exists error should not be thrown");
       }
     }
+  }
+
+  @Test
+  public void testJobCreationMode() throws InterruptedException {
+    String query = "SELECT 1 as one";
+    QueryJobConfiguration config =
+        QueryJobConfiguration.newBuilder(query)
+            .setJobCreationMode(JobCreationMode.JOB_CREATION_OPTIONAL)
+            .build();
+    TableResult result = bigquery.query(config);
+    assertNull(result.getJobId());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-bigquery-parent</site.installationModule>
-    <google-api-services-bigquery.version>v2-rev20230812-2.0.0</google-api-services-bigquery.version>
+    <google-api-services-bigquery.version>v2-rev20230925-2.0.0</google-api-services-bigquery.version>
     <google.cloud.shared-dependencies.version>3.16.1</google.cloud.shared-dependencies.version>
     <arrow.version>12.0.1</arrow.version>
   </properties>


### PR DESCRIPTION
Enables preview query features, which currently only includes stateless queries (queries without jobId). These features won't always be enabled on the service side and there are additional checks and conditions.

Fixes https://github.com/googleapis/java-bigquery/issues/2949