### PR TITLE
build: do not declare javadoc plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.23.0')
+implementation platform('com.google.cloud:libraries-bom:26.24.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <reportSets>
           <reportSet>
             <id>html</id>


### PR DESCRIPTION
The maven-javadoc-plugin version is defined in the shared config pom.xml.
https://github.com/googleapis/java-shared-config/blob/778a547a09de71dbf9e5a42b155f12d15c319864/pom.xml#L472

The removal of the 4 lines corresponds to the lines touched by the recent RenovateBot:
https://github.com/googleapis/java-bigquery/pull/2887/files

Parent issue: https://github.com/googleapis/java-shared-config/issues/673