### PR TITLE
fix: update TableInsertRows.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.26.0')
+implementation platform('com.google.cloud:libraries-bom:26.27.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/samples/snippets/src/main/java/com/example/bigquery/TableInsertRows.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/TableInsertRows.java
@@ -39,12 +39,13 @@ public class TableInsertRows {
     Map<String, Object> rowContent = new HashMap<>();
     rowContent.put("booleanField", true);
     rowContent.put("numericField", "3.14");
-
-    tableInsertRows(datasetName, tableName, rowContent);
+    // TODO(developer): Replace the row id with a unique value for each row.
+    String rowId = "ROW_ID";
+    tableInsertRows(datasetName, tableName, rowId, rowContent);
   }
 
   public static void tableInsertRows(
-      String datasetName, String tableName, Map<String, Object> rowContent) {
+      String datasetName, String tableName, String rowId, Map<String, Object> rowContent) {
     try {
       // Initialize client that will be used to send requests. This client only needs to be created
       // once, and can be reused for multiple requests.
@@ -58,9 +59,8 @@ public class TableInsertRows {
           bigquery.insertAll(
               InsertAllRequest.newBuilder(tableId)
                   // More rows can be added in the same RPC by invoking .addRow() on the builder.
-                  // You can also supply optional unique row keys to support de-duplication
-                  // scenarios.
-                  .addRow(rowContent)
+                  // You can omit the unique row ids to disable de-duplication.
+                  .addRow(rowId, rowContent)
                   .build());
 
       if (response.hasErrors()) {

--- a/samples/snippets/src/main/java/com/example/bigquery/TableInsertRowsWithoutRowIds.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/TableInsertRowsWithoutRowIds.java
@@ -54,6 +54,8 @@ public class TableInsertRowsWithoutRowIds {
       InsertAllResponse response =
           bigquery.insertAll(
               InsertAllRequest.newBuilder(TableId.of(datasetName, tableName))
+                  // No row ids disable de-duplication, and also disable the retries in the Java
+                  // library.
                   .setRows(
                       ImmutableList.of(
                           InsertAllRequest.RowToInsert.of(rowContent1),

--- a/samples/snippets/src/test/java/com/example/bigquery/TableInsertRowsIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/TableInsertRowsIT.java
@@ -88,8 +88,9 @@ public class TableInsertRowsIT {
     Map<String, Object> rowContent = new HashMap<>();
     rowContent.put("booleanField", true);
     rowContent.put("numericField", "3.14");
+    String rowId = "ROW_ID";
     // Testing
-    TableInsertRows.tableInsertRows(BIGQUERY_DATASET_NAME, tableName, rowContent);
+    TableInsertRows.tableInsertRows(BIGQUERY_DATASET_NAME, tableName, rowId, rowContent);
     assertThat(bout.toString()).contains("Rows successfully inserted into table");
   }
 }


### PR DESCRIPTION
Make the example set row id in `addRow`. If row id is missed, it disable the retry b/280865468, which I believe an unexpected behavior to users.

Fixes #3000.