### PR TITLE
Feat: Update universe domain exception error code/message

### DIFF
--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -52,6 +52,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>
     <dependency>

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigquery.spi.v2;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.http.GenericUrl;
@@ -116,7 +117,11 @@ public class HttpBigQueryRpc implements BigQueryRpc {
 
   private void validateRPC() throws BigQueryException, IOException {
     if (!this.options.hasValidUniverseDomain()) {
-      throw new BigQueryException(BigQueryException.UNKNOWN_CODE, "Invalid universe domain");
+      String errorMessage =
+          String.format(
+              "The configured universe domain %s does not match the universe domain found in the credentials %s. If you haven't configured the universe domain explicitly, `googleapis.com` is the default.",
+              this.options.getUniverseDomain(), this.options.getCredentials().getUniverseDomain());
+      throw new BigQueryException(HTTP_UNAUTHORIZED, errorMessage);
     }
   }
 

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigquery.it;
 import static com.google.cloud.bigquery.JobStatus.State.DONE;
 import static com.google.common.truth.Truth.assertThat;
 import static java.lang.System.currentTimeMillis;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -6402,8 +6403,12 @@ public class ITBigQueryTest {
       bigQuery.listDatasets("bigquery-public-data");
       fail("RPCs to invalid universe domain should fail");
     } catch (BigQueryException e) {
+      assertEquals(e.getCode(), HTTP_UNAUTHORIZED);
       assertNotNull(e.getMessage());
-      assertThat((e.getMessage().contains("Invalid universe domain"))).isTrue();
+      assertThat(
+              (e.getMessage()
+                  .contains("does not match the universe domain found in the credentials")))
+          .isTrue();
     }
   }
 
@@ -6423,8 +6428,12 @@ public class ITBigQueryTest {
       bigQuery.listDatasets("bigquery-public-data");
       fail("RPCs to invalid universe domain should fail");
     } catch (BigQueryException e) {
+      assertEquals(e.getCode(), HTTP_UNAUTHORIZED);
       assertNotNull(e.getMessage());
-      assertThat((e.getMessage().contains("Invalid universe domain"))).isTrue();
+      assertThat(
+              (e.getMessage()
+                  .contains("does not match the universe domain found in the credentials")))
+          .isTrue();
     }
   }
 


### PR DESCRIPTION
This PR updates the universe domain except error code/message to be consistent with the error message used in GAPIC. Specifically, with the error code 401 and the message "The configured universe domain (googleapis.com) does not match the universe domain found in the credentials (foo.com). If you haven't configured the universe domain explicitly, googleapis.com is the default."

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #3112