### PR TITLE
feat: add MetadataCacheStatistics to Job QueryStatistics

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-java:latest
-  digest: sha256:a6aa751984f1e905c3ae5a3aac78fc7b68210626ce91487dc7ff4f0a06f010cc
-# created: 2024-01-22T14:14:20.913785597Z
+  digest: sha256:0d1bb26a1a99ae0456176bf891b8490e9aab424a5cb4e4d301d9703c4dc43b58
+# created: 2024-01-30T19:46:55.029238294Z

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.30.0')
+implementation platform('com.google.cloud:libraries-bom:26.31.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.31.0')
+implementation platform('com.google.cloud:libraries-bom:26.32.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.37.1'
+implementation 'com.google.cloud:google-cloud-bigquery:2.37.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.37.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.37.2"
 ```
 <!-- {x-version-update-end} -->
 
@@ -351,7 +351,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquery/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquery.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.37.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.37.2
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
@@ -358,9 +358,7 @@ public abstract class JobStatistics implements Serializable {
     private final List<TimelineSample> timeline;
     private final Schema schema;
     private final SearchStats searchStats;
-
     private final MetadataCacheStats metadataCacheStats;
-
     private final List<QueryParameter> queryParameters;
 
     /**

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
@@ -358,6 +358,9 @@ public abstract class JobStatistics implements Serializable {
     private final List<TimelineSample> timeline;
     private final Schema schema;
     private final SearchStats searchStats;
+
+    private final MetadataCacheStats metadataCacheStats;
+
     private final List<QueryParameter> queryParameters;
 
     /**
@@ -444,6 +447,8 @@ public abstract class JobStatistics implements Serializable {
       private List<QueryParameter> queryParameters;
       private SearchStats searchStats;
 
+      private MetadataCacheStats metadataCacheStats;
+
       private Builder() {}
 
       private Builder(com.google.api.services.bigquery.model.JobStatistics statisticsPb) {
@@ -492,6 +497,10 @@ public abstract class JobStatistics implements Serializable {
           }
           if (statisticsPb.getQuery().getSearchStatistics() != null) {
             this.searchStats = SearchStats.fromPb(statisticsPb.getQuery().getSearchStatistics());
+          }
+          if (statisticsPb.getQuery().getMetadataCacheStatistics() != null) {
+            this.metadataCacheStats =
+                MetadataCacheStats.fromPb(statisticsPb.getQuery().getMetadataCacheStatistics());
           }
           if (statisticsPb.getQuery().getDmlStats() != null) {
             this.dmlStats = DmlStats.fromPb(statisticsPb.getQuery().getDmlStats());
@@ -599,6 +608,11 @@ public abstract class JobStatistics implements Serializable {
         return self();
       }
 
+      Builder setMetadataCacheStats(MetadataCacheStats metadataCacheStats) {
+        this.metadataCacheStats = metadataCacheStats;
+        return self();
+      }
+
       Builder setQueryParameters(List<QueryParameter> queryParameters) {
         this.queryParameters = queryParameters;
         return self();
@@ -631,6 +645,7 @@ public abstract class JobStatistics implements Serializable {
       this.timeline = builder.timeline;
       this.schema = builder.schema;
       this.searchStats = builder.searchStats;
+      this.metadataCacheStats = builder.metadataCacheStats;
       this.queryParameters = builder.queryParameters;
     }
 
@@ -761,6 +776,11 @@ public abstract class JobStatistics implements Serializable {
       return searchStats;
     }
 
+    /** Statistics for metadata caching in BigLake tables. */
+    public MetadataCacheStats getMetadataCacheStats() {
+      return metadataCacheStats;
+    }
+
     /**
      * Standard SQL only: Returns a list of undeclared query parameters detected during a dry run
      * validation.
@@ -781,6 +801,7 @@ public abstract class JobStatistics implements Serializable {
           .add("timeline", timeline)
           .add("schema", schema)
           .add("searchStats", searchStats)
+          .add("metadataCacheStats", metadataCacheStats)
           .add("queryParameters", queryParameters);
     }
 
@@ -804,6 +825,7 @@ public abstract class JobStatistics implements Serializable {
           queryPlan,
           schema,
           searchStats,
+          metadataCacheStats,
           queryParameters);
     }
 
@@ -848,6 +870,9 @@ public abstract class JobStatistics implements Serializable {
       }
       if (searchStats != null) {
         queryStatisticsPb.setSearchStatistics(searchStats.toPb());
+      }
+      if (metadataCacheStats != null) {
+        queryStatisticsPb.setMetadataCacheStatistics(metadataCacheStats.toPb());
       }
       if (queryParameters != null) {
         queryStatisticsPb.setUndeclaredQueryParameters(queryParameters);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/MetadataCacheStats.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/MetadataCacheStats.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *e
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/MetadataCacheStats.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/MetadataCacheStats.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *e
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery;
+
+import com.google.api.services.bigquery.model.MetadataCacheStatistics;
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/** Represents statistics for metadata caching in BigLake tables. */
+@AutoValue
+public abstract class MetadataCacheStats implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    /** Sets the free form human-readable reason metadata caching was unused for the job. */
+    public abstract MetadataCacheStats.Builder setTableMetadataCacheUsage(
+        List<TableMetadataCacheUsage> tableMetadataCacheUsage);
+
+    /** Creates a @code MetadataCacheStats} object. */
+    public abstract MetadataCacheStats build();
+  }
+
+  public abstract Builder toBuilder();
+
+  public static Builder newBuilder() {
+    return new AutoValue_MetadataCacheStats.Builder();
+  }
+
+  @Nullable
+  public abstract List<TableMetadataCacheUsage> getTableMetadataCacheUsage();
+
+  MetadataCacheStatistics toPb() {
+    MetadataCacheStatistics metadataCacheStatistics = new MetadataCacheStatistics();
+    if (getTableMetadataCacheUsage() != null) {
+      metadataCacheStatistics.setTableMetadataCacheUsage(
+          getTableMetadataCacheUsage().stream()
+              .map(TableMetadataCacheUsage::toPb)
+              .collect(Collectors.toList()));
+    }
+    return metadataCacheStatistics;
+  }
+
+  static MetadataCacheStats fromPb(MetadataCacheStatistics metadataCacheStatistics) {
+    Builder builder = newBuilder();
+    if (metadataCacheStatistics.getTableMetadataCacheUsage() != null) {
+      builder.setTableMetadataCacheUsage(
+          metadataCacheStatistics.getTableMetadataCacheUsage().stream()
+              .map(TableMetadataCacheUsage::fromPb)
+              .collect(Collectors.toList()));
+    }
+    return builder.build();
+  }
+}

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/MetadataCacheStats.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/MetadataCacheStats.java
@@ -23,7 +23,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-/** Represents statistics for metadata caching in BigLake tables. */
+/**
+ * Represents statistics for metadata caching in BigLake tables.
+ *
+ * @see <a href="https://cloud.google.com/bigquery/docs/biglake-intro">BigLake Tables</a>
+ */
 @AutoValue
 public abstract class MetadataCacheStats implements Serializable {
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableMetadataCacheUsage.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableMetadataCacheUsage.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/** Represents Table level detail on the usage of metadata caching. */
+@AutoValue
+public abstract class TableMetadataCacheUsage implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Reason for not using metadata caching for the table. */
+  public enum UnusedReason {
+    /** Unused reasons not specified. */
+    UNUSED_REASON_UNSPECIFIED,
+
+    /** Metadata cache was outside the table's maxStaleness. */
+    EXCEEDED_MAX_STALENESS,
+
+    /**
+     * Metadata caching feature is not enabled. Update BigLake tables to enable the metadata
+     * caching.
+     */
+    METADATA_CACHING_NOT_ENABLED,
+
+    /** Other unknown reason. */
+    OTHER_REASON
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    /** Sets the free form human-readable reason metadata caching was unused for the job. */
+    public abstract TableMetadataCacheUsage.Builder setExplanation(String explanation);
+
+    /** Sets the metadata caching eligible table referenced in the query. */
+    public abstract TableMetadataCacheUsage.Builder setTableReference(TableId tableReference);
+
+    /** Sets the table type. */
+    public abstract TableMetadataCacheUsage.Builder setTableType(String tableType);
+
+    /** Sets reason for not using metadata caching for the table. */
+    public abstract TableMetadataCacheUsage.Builder setUnusedReason(UnusedReason unusedReason);
+
+    /** Creates a @code TableMetadataCacheUsage} object. */
+    public abstract TableMetadataCacheUsage build();
+  }
+
+  public abstract Builder toBuilder();
+
+  public static Builder newBuilder() {
+    return new AutoValue_TableMetadataCacheUsage.Builder();
+  }
+
+  @Nullable
+  public abstract String getExplanation();
+
+  @Nullable
+  public abstract TableId getTableReference();
+
+  @Nullable
+  public abstract String getTableType();
+
+  @Nullable
+  public abstract UnusedReason getUnusedReason();
+
+  com.google.api.services.bigquery.model.TableMetadataCacheUsage toPb() {
+    com.google.api.services.bigquery.model.TableMetadataCacheUsage tableMetadataCacheUsage =
+        new com.google.api.services.bigquery.model.TableMetadataCacheUsage();
+    if (getExplanation() != null) {
+      tableMetadataCacheUsage.setExplanation(getExplanation());
+    }
+    if (getTableReference() != null) {
+      tableMetadataCacheUsage.setTableReference(getTableReference().toPb());
+    }
+    if (getTableType() != null) {
+      tableMetadataCacheUsage.setTableType(getTableType());
+    }
+    if (getUnusedReason() != null) {
+      tableMetadataCacheUsage.setUnusedReason(getUnusedReason().toString());
+    }
+    return tableMetadataCacheUsage;
+  }
+
+  static TableMetadataCacheUsage fromPb(
+      com.google.api.services.bigquery.model.TableMetadataCacheUsage tableMetadataCacheUsage) {
+    Builder builder = newBuilder();
+    if (tableMetadataCacheUsage.getExplanation() != null) {
+      builder.setExplanation(tableMetadataCacheUsage.getExplanation());
+    }
+    if (tableMetadataCacheUsage.getTableReference() != null) {
+      builder.setTableReference(TableId.fromPb(tableMetadataCacheUsage.getTableReference()));
+    }
+    if (tableMetadataCacheUsage.getTableType() != null) {
+      builder.setTableType(tableMetadataCacheUsage.getTableType());
+    }
+    if (tableMetadataCacheUsage.getUnusedReason() != null) {
+      builder.setUnusedReason(UnusedReason.valueOf(tableMetadataCacheUsage.getUnusedReason()));
+    }
+    return builder.build();
+  }
+}

--- a/google-cloud-bigquery/src/test/java/MetadataCacheStatsTest.java
+++ b/google-cloud-bigquery/src/test/java/MetadataCacheStatsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.services.bigquery.model.MetadataCacheStatistics;
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class MetadataCacheStatsTest {
+  private static List<com.google.api.services.bigquery.model.TableMetadataCacheUsage>
+      TABLE_METADATA_CACHE_USAGE_PB_LIST =
+          ImmutableList.of(
+              new com.google.api.services.bigquery.model.TableMetadataCacheUsage()
+                  .setExplanation("test explanation"));
+
+  private static final MetadataCacheStats METADATA_CACHE_STATS =
+      MetadataCacheStats.newBuilder()
+          .setTableMetadataCacheUsage(
+              TABLE_METADATA_CACHE_USAGE_PB_LIST.stream()
+                  .map(TableMetadataCacheUsage::fromPb)
+                  .collect(Collectors.toList()))
+          .build();
+
+  private static final MetadataCacheStatistics METADATA_CACHE_STATISTICS_PB =
+      new MetadataCacheStatistics().setTableMetadataCacheUsage(TABLE_METADATA_CACHE_USAGE_PB_LIST);
+
+  @Test
+  public void testToPbAndFromPb() {
+    assertEquals(METADATA_CACHE_STATISTICS_PB, METADATA_CACHE_STATS.toPb());
+    compareMetadataCacheStats(
+        METADATA_CACHE_STATS, MetadataCacheStats.fromPb(METADATA_CACHE_STATISTICS_PB));
+  }
+
+  private void compareMetadataCacheStats(MetadataCacheStats expected, MetadataCacheStats value) {
+    assertEquals(expected, value);
+    assertEquals(expected.hashCode(), value.hashCode());
+    assertEquals(expected.toString(), value.toString());
+    Truth.assertThat(
+        expected.getTableMetadataCacheUsage().containsAll(value.getTableMetadataCacheUsage()));
+  }
+}

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/JobStatisticsTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/JobStatisticsTest.java
@@ -163,6 +163,14 @@ public class JobStatisticsTest {
   private static final String UNUSED_INDEX_USAGE_MODE = "UNUSED";
   private static final SearchStats SEARCH_STATS =
       SearchStats.newBuilder().setIndexUsageMode(UNUSED_INDEX_USAGE_MODE).build();
+
+  private static final MetadataCacheStats METADATA_CACHE_STATS =
+      MetadataCacheStats.newBuilder()
+          .setTableMetadataCacheUsage(
+              ImmutableList.of(
+                  TableMetadataCacheUsage.newBuilder().setExplanation("test explanation").build()))
+          .build();
+
   private static final QueryStatistics QUERY_STATISTICS =
       QueryStatistics.newBuilder()
           .setCreationTimestamp(CREATION_TIME)
@@ -187,6 +195,7 @@ public class JobStatisticsTest {
           .setTimeline(TIMELINE)
           .setSchema(SCHEMA)
           .setSearchStats(SEARCH_STATS)
+          .setMetadataCacheStats(METADATA_CACHE_STATS)
           .build();
   private static final QueryStatistics QUERY_STATISTICS_INCOMPLETE =
       QueryStatistics.newBuilder()
@@ -196,6 +205,7 @@ public class JobStatisticsTest {
           .setBillingTier(BILLING_TIER)
           .setCacheHit(CACHE_HIT)
           .setSearchStats(SEARCH_STATS)
+          .setMetadataCacheStats(METADATA_CACHE_STATS)
           .build();
   private static final ScriptStackFrame STATEMENT_STACK_FRAME =
       ScriptStackFrame.newBuilder()
@@ -417,6 +427,7 @@ public class JobStatisticsTest {
     assertEquals(expected.getSchema(), value.getSchema());
     assertEquals(
         expected.getSearchStats().getIndexUsageMode(), value.getSearchStats().getIndexUsageMode());
+    assertEquals(expected.getMetadataCacheStats(), value.getMetadataCacheStats());
     assertEquals(expected.getStatementType(), value.getStatementType());
     assertEquals(expected.getTimeline(), value.getTimeline());
   }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableMetadataCacheUsageTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableMetadataCacheUsageTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.cloud.bigquery.TableMetadataCacheUsage.UnusedReason;
+import org.junit.Test;
+
+public class TableMetadataCacheUsageTest {
+
+  private static final String EXPLANATION = "test explanation";
+
+  private static final String TABLE_TYPE = "test tableType";
+
+  private static final UnusedReason UNUSED_REASON = UnusedReason.UNUSED_REASON_UNSPECIFIED;
+  private static final TableReference TABLE_REFERENCE =
+      new TableReference()
+          .setTableId("test tableId")
+          .setProjectId("test projectId")
+          .setDatasetId("test dataset");
+  private static final TableMetadataCacheUsage TABLE_METADATA_CACHE_USAGE =
+      TableMetadataCacheUsage.newBuilder()
+          .setExplanation(EXPLANATION)
+          .setTableType(TABLE_TYPE)
+          .setUnusedReason(UNUSED_REASON)
+          .setTableReference(TableId.fromPb(TABLE_REFERENCE))
+          .build();
+
+  private static final com.google.api.services.bigquery.model.TableMetadataCacheUsage
+      TABLE_METADATA_CACHE_USAGE_PB =
+          new com.google.api.services.bigquery.model.TableMetadataCacheUsage()
+              .setTableReference(TABLE_REFERENCE)
+              .setExplanation(EXPLANATION)
+              .setTableType(TABLE_TYPE)
+              .setUnusedReason(UNUSED_REASON.toString());
+
+  @Test
+  public void testToPbAndFromPb() {
+    assertEquals(TABLE_METADATA_CACHE_USAGE_PB, TABLE_METADATA_CACHE_USAGE.toPb());
+    compareTableMetadataCacheUsage(
+        TABLE_METADATA_CACHE_USAGE, TableMetadataCacheUsage.fromPb(TABLE_METADATA_CACHE_USAGE_PB));
+  }
+
+  private void compareTableMetadataCacheUsage(
+      TableMetadataCacheUsage expected, TableMetadataCacheUsage value) {
+    assertEquals(expected, value);
+    assertEquals(expected.hashCode(), value.hashCode());
+    assertEquals(expected.toString(), value.toString());
+    assertEquals(expected.getExplanation(), value.getExplanation());
+    assertEquals(expected.getTableType(), value.getTableType());
+    assertEquals(expected.getUnusedReason(), value.getUnusedReason());
+    assertEquals(expected.getTableReference(), value.getTableReference());
+  }
+}

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -125,6 +125,7 @@ import com.google.cloud.bigquery.TableDataWriteChannel;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TableMetadataCacheUsage.UnusedReason;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.TimePartitioning.Type;
@@ -1881,7 +1882,7 @@ public class ITBigQueryTest {
       rowCount++;
     }
     assertEquals(4, rowCount);
-    assertTrue(remoteTable.delete());
+    // assertTrue(remoteTable.delete());
   }
 
   @Test
@@ -6446,6 +6447,47 @@ public class ITBigQueryTest {
     for (String type : PUBLIC_DATASETS) {
       assertTrue(datasetNames.contains(type));
     }
+  }
+
+  @Test
+  public void testExternalTableMetadataCachingNotEnable() throws InterruptedException {
+    String tableName = "test_metadata_cache_not_enable";
+    TableId tableId = TableId.of(DATASET, tableName);
+    ExternalTableDefinition externalTableDefinition =
+        ExternalTableDefinition.of(
+            "gs://" + BUCKET + "/" + JSON_LOAD_FILE, TABLE_SCHEMA, FormatOptions.json());
+    TableInfo tableInfo = TableInfo.of(tableId, externalTableDefinition);
+    Table createdTable = bigquery.create(tableInfo);
+    assertNotNull(createdTable);
+    assertEquals(DATASET, createdTable.getTableId().getDataset());
+    assertEquals(tableName, createdTable.getTableId().getTable());
+    Table remoteTable = bigquery.getTable(DATASET, tableName);
+    assertNotNull(remoteTable);
+    assertTrue(remoteTable.getDefinition() instanceof ExternalTableDefinition);
+    assertEquals(createdTable.getTableId(), remoteTable.getTableId());
+    assertEquals(TABLE_SCHEMA, remoteTable.getDefinition().getSchema());
+
+    String query = String.format("SELECT * FROM  %s.%s", DATASET, tableName);
+    QueryJobConfiguration config = QueryJobConfiguration.newBuilder(query).build();
+
+    Job remoteJob = bigquery.create(JobInfo.of(config));
+    remoteJob = remoteJob.waitFor();
+    assertNull(remoteJob.getStatus().getError());
+
+    Job queryJob = bigquery.getJob(remoteJob.getJobId());
+    JobStatistics.QueryStatistics statistics = queryJob.getStatistics();
+    assertNotNull(statistics);
+    assertNotNull(statistics.getMetadataCacheStats());
+    assertThat(statistics.getMetadataCacheStats().getTableMetadataCacheUsage().size()).isEqualTo(1);
+    assertThat(
+            statistics
+                .getMetadataCacheStats()
+                .getTableMetadataCacheUsage()
+                .get(0)
+                .getUnusedReason())
+        .isEqualTo(UnusedReason.METADATA_CACHING_NOT_ENABLED);
+
+    assertTrue(remoteTable.delete());
   }
 
   static GoogleCredentials loadCredentials(String credentialFile) {

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1882,7 +1882,7 @@ public class ITBigQueryTest {
       rowCount++;
     }
     assertEquals(4, rowCount);
-    // assertTrue(remoteTable.delete());
+    assertTrue(remoteTable.delete());
   }
 
   @Test


### PR DESCRIPTION
Note: This only includes IT test for when the external table does not have metadata cache enabled. Since we are moving away from the GCP java-docs-samples-testing, the IT for when metadata cache enabled with be added after the migration due to the need to create BigLake table with external connection.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #3134 ☕️
