### PR TITLE
chore: adding google-cloud-bigquery-bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.31.0')
+implementation platform('com.google.cloud:libraries-bom:26.32.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/google-cloud-bigquery-bom/pom.xml
+++ b/google-cloud-bigquery-bom/pom.xml
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigquery-bom</artifactId>
+    <version>2.37.0</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+    <packaging>pom</packaging>
+    <parent>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-shared-config</artifactId>
+        <version>1.7.1</version>
+        <relativePath/>
+    </parent>
+
+    <name>Google Cloud BigQuery BOM</name>
+    <url>https://github.com/googleapis/java-bigquery</url>
+    <description>
+      BOM for Google Cloud BigQuery
+    </description>
+
+    <organization>
+      <name>Google LLC</name>
+    </organization>
+
+    <developers>
+      <developer>
+        <id>suztomo</id>
+        <name>Tomo Suzuki</name>
+        <email>suztomo@google.com</email>
+        <organization>Google LLC</organization>
+        <roles>
+          <role>Developer</role>
+        </roles>
+      </developer>
+    </developers>
+
+    <scm>
+      <connection>scm:git:https://github.com/googleapis/java-bigquery.git</connection>
+      <developerConnection>scm:git:git@github.com:googleapis/java-bigquery.git</developerConnection>
+      <url>https://github.com/googleapis/java-bigquery</url>
+    </scm>
+
+
+    <licenses>
+      <license>
+        <name>The Apache Software License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+      </license>
+    </licenses>
+
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-bigquery</artifactId>
+          <version>2.37.0</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+
+        <!-- Using maven site plugin only as a hook for javadoc:aggregate, don't need the reports -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+
+          <configuration>
+            <generateReports>false</generateReports>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
 
   <modules>
     <module>google-cloud-bigquery</module>
+    <module>google-cloud-bigquery-bom</module>
   </modules>
 
   <build>


### PR DESCRIPTION
The BOM declares the published artifacts from this repository. (Historically, this repository has only published one artifact and thus maintainers haven't had a need of creating a BOM.)