### PR TITLE
chore: use sdk-platform-java-config to consolidate build configs

### DIFF
--- a/.kokoro/continuous/graalvm-native-17.cfg
+++ b/.kokoro/continuous/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.25.0"
 }
 
 env_vars: {

--- a/.kokoro/continuous/graalvm-native.cfg
+++ b/.kokoro/continuous/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.25.0"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.25.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.25.0"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.25.0""
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.25.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.25.0"
 }
 
 env_vars: {

--- a/owlbot.py
+++ b/owlbot.py
@@ -20,6 +20,8 @@ java.common_templates(excludes=[
     '.kokoro/nightly/samples.cfg',
     '.kokoro/nightly/integration.cfg',
     '.kokoro/presubmit/samples.cfg',
+    '.kokoro/presubmit/graalvm-native.cfg',
+    '.kokoro/presubmit/graalvm-native-17.cfg',
     'codecov.yaml',
     'renovate.json',
     '.kokoro/build.sh'

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.1</version>
+    <artifactId>sdk-platform-java-config</artifactId>
+    <version>3.25.0</version>
   </parent>
 
   <developers>
@@ -55,7 +55,6 @@
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-bigquery-parent</site.installationModule>
     <google-api-services-bigquery.version>v2-rev20240203-2.0.0</google-api-services-bigquery.version>
-    <google.cloud.shared-dependencies.version>3.25.0</google.cloud.shared-dependencies.version>
     <arrow.version>15.0.0</arrow.version>
   </properties>
 
@@ -64,7 +63,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>${google.cloud.shared-dependencies.version}</version>
+        <version>${google-cloud-shared-dependencies.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,18 @@
     ":autodetectPinVersions"
   ],
   "ignorePaths": [".kokoro/requirements.txt"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.kokoro/continuous/graalvm-native.*.cfg$",
+        "^.kokoro/presubmit/graalvm-native.*.cfg$"
+      ],
+      "matchStrings": ["value: \"gcr.io/cloud-devrel-public-resources/graalvm.*:(?<currentValue>.*?)\""],
+      "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
+      "datasourceTemplate": "maven"
+    }
+  ],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
Notable Changes:
1) Use `gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform*` docker images for Kokoro GraalVM tests  instead of `gcr.io/cloud-devrel-kokoro-resources/graalvm*`.
2) Use `com.google.cloud:sdk-platform-java-config` as the parent which inherits configs from `java-shared-config` and hosts the `google-cloud-shared-dependencies` version under the `google-cloud-shared-dependencies.version` property.  This artifact is versioned to be the same as google-cloud-shared-dependencies.
3) Adjust renovate-bot settings to update docker images when a new version of `sdk-platform-java-config` is on Maven Central.

Example renovate-bot update PR in google-cloud-java: https://github.com/googleapis/google-cloud-java/pull/10290