### PR TITLE
Make setDescription public on RoutineInfo.Builder

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/RoutineInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/RoutineInfo.java
@@ -90,7 +90,7 @@ public class RoutineInfo implements Serializable {
     abstract Builder setCreationTime(Long creationMillis);
 
     /** Sets the description for the routine. */
-    abstract Builder setDescription(String description);
+    public abstract Builder setDescription(String description);
 
     abstract Builder setLastModifiedTime(Long lastModifiedMillis);
 


### PR DESCRIPTION
Previously it was not possible to use RoutineInfo.Builder directly to set the description.

It was possible via the Routine.Builder, but this allows users to not care about this fact.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #3169
