### PR TITLE
Fix: @Nullable annotations on builder methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.38.2'
+implementation 'com.google.cloud:google-cloud-bigquery:2.39.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.38.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.39.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -351,7 +351,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquery/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquery.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.38.2
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.39.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.34.0')
+implementation platform('com.google.cloud:libraries-bom:26.37.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
@@ -36,7 +36,8 @@ public abstract class ConnectionSettings {
    * Returns useReadAPI flag, enabled by default. Read API will be used if the underlying conditions
    * are satisfied and this flag is enabled
    */
-  public abstract boolean getUseReadAPI();
+  @Nullable
+  public abstract Boolean getUseReadAPI();
 
   /** Returns the synchronous response timeoutMs associated with this query */
   @Nullable
@@ -220,7 +221,7 @@ public abstract class ConnectionSettings {
      *
      * @param useReadAPI or {@code true} for none
      */
-    public abstract Builder setUseReadAPI(boolean useReadAPI);
+    public abstract Builder setUseReadAPI(Boolean useReadAPI);
 
     /**
      * Sets how long to wait for the query to complete, in milliseconds, before the request times

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
@@ -36,8 +36,7 @@ public abstract class ConnectionSettings {
    * Returns useReadAPI flag, enabled by default. Read API will be used if the underlying conditions
    * are satisfied and this flag is enabled
    */
-  @Nullable
-  public abstract Boolean getUseReadAPI();
+  public abstract boolean getUseReadAPI();
 
   /** Returns the synchronous response timeoutMs associated with this query */
   @Nullable
@@ -221,7 +220,7 @@ public abstract class ConnectionSettings {
      *
      * @param useReadAPI or {@code true} for none
      */
-    public abstract Builder setUseReadAPI(@Nullable Boolean useReadAPI);
+    public abstract Builder setUseReadAPI(boolean useReadAPI);
 
     /**
      * Sets how long to wait for the query to complete, in milliseconds, before the request times

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java
@@ -221,8 +221,7 @@ public abstract class ConnectionSettings {
      *
      * @param useReadAPI or {@code true} for none
      */
-    @Nullable
-    public abstract Builder setUseReadAPI(Boolean useReadAPI);
+    public abstract Builder setUseReadAPI(@Nullable Boolean useReadAPI);
 
     /**
      * Sets how long to wait for the query to complete, in milliseconds, before the request times

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ReadClientConnectionConfiguration.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ReadClientConnectionConfiguration.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigquery;
 
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
-import javax.annotation.Nullable;
 
 /** Represents BigQueryStorage Read client connection information. */
 @AutoValue
@@ -31,21 +30,18 @@ public abstract class ReadClientConnectionConfiguration implements Serializable 
      * Sets the total row count to page row count ratio used to determine whether to us the
      * BigQueryStorage Read client to fetch result sets after the first page.
      */
-    @Nullable
     public abstract Builder setTotalToPageRowCountRatio(Long ratio);
 
     /**
      * Sets the minimum number of table rows in the query results used to determine whether to us
      * the BigQueryStorage Read client to fetch result sets after the first page.
      */
-    @Nullable
     public abstract Builder setMinResultSize(Long numRows);
 
     /**
      * Sets the maximum number of table rows allowed in buffer before streaming them to the
      * BigQueryResult.
      */
-    @Nullable
     public abstract Builder setBufferSize(Long bufferSize);
 
     /** Creates a {@code ReadClientConnectionConfiguration} object. */

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ReadClientConnectionConfiguration.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ReadClientConnectionConfiguration.java
@@ -31,34 +31,34 @@ public abstract class ReadClientConnectionConfiguration implements Serializable 
      * Sets the total row count to page row count ratio used to determine whether to us the
      * BigQueryStorage Read client to fetch result sets after the first page.
      */
-    public abstract Builder setTotalToPageRowCountRatio(@Nullable Long ratio);
+    public abstract Builder setTotalToPageRowCountRatio(Long ratio);
 
     /**
      * Sets the minimum number of table rows in the query results used to determine whether to us
      * the BigQueryStorage Read client to fetch result sets after the first page.
      */
-    public abstract Builder setMinResultSize(@Nullable Long numRows);
+    public abstract Builder setMinResultSize(Long numRows);
 
     /**
      * Sets the maximum number of table rows allowed in buffer before streaming them to the
      * BigQueryResult.
      */
-    public abstract Builder setBufferSize(@Nullable Long bufferSize);
+    public abstract Builder setBufferSize(Long bufferSize);
 
     /** Creates a {@code ReadClientConnectionConfiguration} object. */
     public abstract ReadClientConnectionConfiguration build();
   }
 
   /** Returns the totalToPageRowCountRatio in this configuration. */
-  @Nullable 
+  @Nullable
   public abstract Long getTotalToPageRowCountRatio();
 
   /** Returns the minResultSize in this configuration. */
-  @Nullable 
+  @Nullable
   public abstract Long getMinResultSize();
 
   /** Returns the bufferSize in this configuration. */
-  @Nullable 
+  @Nullable
   public abstract Long getBufferSize();
 
   public abstract Builder toBuilder();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ReadClientConnectionConfiguration.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ReadClientConnectionConfiguration.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery;
 
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 
 /** Represents BigQueryStorage Read client connection information. */
 @AutoValue
@@ -30,31 +31,34 @@ public abstract class ReadClientConnectionConfiguration implements Serializable 
      * Sets the total row count to page row count ratio used to determine whether to us the
      * BigQueryStorage Read client to fetch result sets after the first page.
      */
-    public abstract Builder setTotalToPageRowCountRatio(Long ratio);
+    public abstract Builder setTotalToPageRowCountRatio(@Nullable Long ratio);
 
     /**
      * Sets the minimum number of table rows in the query results used to determine whether to us
      * the BigQueryStorage Read client to fetch result sets after the first page.
      */
-    public abstract Builder setMinResultSize(Long numRows);
+    public abstract Builder setMinResultSize(@Nullable Long numRows);
 
     /**
      * Sets the maximum number of table rows allowed in buffer before streaming them to the
      * BigQueryResult.
      */
-    public abstract Builder setBufferSize(Long bufferSize);
+    public abstract Builder setBufferSize(@Nullable Long bufferSize);
 
     /** Creates a {@code ReadClientConnectionConfiguration} object. */
     public abstract ReadClientConnectionConfiguration build();
   }
 
   /** Returns the totalToPageRowCountRatio in this configuration. */
+  @Nullable 
   public abstract Long getTotalToPageRowCountRatio();
 
   /** Returns the minResultSize in this configuration. */
+  @Nullable 
   public abstract Long getMinResultSize();
 
   /** Returns the bufferSize in this configuration. */
+  @Nullable 
   public abstract Long getBufferSize();
 
   public abstract Builder toBuilder();


### PR DESCRIPTION
This fixes errors in the latest versions of AutoValue

```
google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionSettings.java:225: error: [AutoValueBuilderSetterNullable] Setter methods always return the Builder so @Nullable is not appropriate
    public abstract Builder setUseReadAPI(Boolean useReadAPI);
                            ^
```

Fixes #3221 ☕️