### PR TITLE
testing: reorder test to avoid racing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.35.0')
+implementation platform('com.google.cloud:libraries-bom:26.37.0')
 
 implementation 'com.google.cloud:google-cloud-bigquery'
 ```

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -5021,13 +5021,12 @@ public class ITBigQueryTest {
     assertNull(remoteJob.getStatus());
     assertNull(remoteJob.getSelfLink());
     assertNull(remoteJob.getUserEmail());
-    assertTrue(createdTable.delete());
-
     Job completedJob =
         remoteJob.waitFor(
             RetryOption.initialRetryDelay(Duration.ofSeconds(1)),
             RetryOption.totalTimeout(Duration.ofMinutes(1)));
     assertNotNull(completedJob);
+    assertTrue(createdTable.delete());
     assertNull(completedJob.getStatus().getError());
     assertTrue(bigquery.delete(destinationTable));
   }


### PR DESCRIPTION
Test involves working with a source table and a job that uses the table as an input.  Reorders the cleanup until after the job is complete to avoid possible racing with deletion before completion.

Fixes: https://github.com/googleapis/java-bigquery/issues/3212