### PR TITLE
testing: address another possible test flake

### DIFF
--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -4973,12 +4973,11 @@ public class ITBigQueryTest {
     assertNotNull(remoteJob.getStatus());
     assertEquals(createdJob.getSelfLink(), remoteJob.getSelfLink());
     assertEquals(createdJob.getUserEmail(), remoteJob.getUserEmail());
-    assertTrue(createdTable.delete());
 
     Job completedJob = remoteJob.waitFor(RetryOption.totalTimeout(Duration.ofMinutes(1)));
-
     assertNotNull(completedJob);
     assertNull(completedJob.getStatus().getError());
+    assertTrue(createdTable.delete());
     assertTrue(bigquery.delete(destinationTable));
   }
 


### PR DESCRIPTION
Another case of deleting resource before job may be done using it.

Fixes: https://github.com/googleapis/java-bigquery/issues/3208
