### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,5 +13,6 @@
   "codeowner_team": "@googleapis/api-bigquery",
   "api_id": "bigquery.googleapis.com",
   "library_type": "GAPIC_MANUAL",
-  "requires_billing": true
+  "requires_billing": true,
+  "recommended_package": "com.google.cloud.bigquery"
 }


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details