### PR TITLE
fix: Remove @InternalApi from TableResult

### DIFF
--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -3,17 +3,6 @@
 <differences>
   <!-- TODO: REMOVE AFTER RELEASE -->
   <difference>
-    <differenceType>3005</differenceType>
-    <className>com/google/cloud/bigquery/TableResult*</className>
-    <justification>TableResult is an internal API and it should be fine to update</justification>
-  </difference>
-  <difference>
-    <differenceType>7002</differenceType>
-    <className>com/google/cloud/bigquery/TableResult*</className>
-    <method>*TableResult(*)</method>
-    <justification>TableResult is an internal API and it should be fine to update</justification>
-  </difference>
-  <difference>
     <differenceType>7004</differenceType>
     <className>com/google/cloud/bigquery/spi/v2/BigQueryRpc</className>
     <method>com.google.api.services.bigquery.model.GetQueryResultsResponse getQueryResultsWithRowLimit(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer)</method>
@@ -24,19 +13,6 @@
     <className>com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc</className>
     <method>com.google.api.services.bigquery.model.GetQueryResultsResponse getQueryResultsWithRowLimit(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer)</method>
     <justification>getQueryResultsWithRowLimit is just used by ConnectionImpl at the moment so it should be fine to update the signature instead of writing an overloaded method</justification>
-  </difference>
-  <difference>
-    <differenceType>7004</differenceType>
-    <className>com/google/cloud/bigquery/TableResult*</className>
-    <method>*TableResult(*)</method>
-    <justification>It should be fine to update TableResult constructors since it is used to return results to the user and users should not directly construct TableResult objects</justification>
-  </difference>
-  <difference>
-    <differenceType>7005</differenceType>
-    <className>com/google/cloud/bigquery/TableResult*</className>
-    <method>*TableResult(*)</method>
-    <to>*TableResult(*)</to>
-    <justification>It should be fine to update TableResult constructors since it is used to return results to the user and users should not directly construct TableResult objects</justification>
   </difference>
   <difference>
     <differenceType>7013</differenceType>
@@ -57,16 +33,6 @@
     <differenceType>7013</differenceType>
     <className>com/google/cloud/bigquery/TableInfo*</className>
     <method>*ResourceTags(*)</method>
-  </difference>
-  <difference>
-    <differenceType>7013</differenceType>
-    <className>com/google/cloud/bigquery/TableResult*</className>
-    <method>*getPageNoSchema(*)</method>
-  </difference>
-  <difference>
-    <differenceType>7013</differenceType>
-    <className>com/google/cloud/bigquery/TableResult*</className>
-    <method>*toBuilder(*)</method>
   </difference>
   <difference>
     <differenceType>7012</differenceType>
@@ -162,9 +128,5 @@
     <differenceType>7013</differenceType>
     <className>com/google/cloud/bigquery/StandardTableDefinition*</className>
     <method>*BigLakeConfiguration(*)</method>
-  </difference>
-  <difference>
-    <differenceType>8001</differenceType>
-    <className>com/google/cloud/bigquery/EmptyTableResult*</className>
   </difference>
   </differences>

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
@@ -27,7 +27,6 @@ import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
-@InternalApi
 @AutoValue
 public abstract class TableResult implements Page<FieldValueList>, Serializable {
 


### PR DESCRIPTION
Since users depends on TableResult in testing, removing @InternalApi forces maintainers to change/roll out changes to TableResult more carefully in the future.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #3215 ☕️