### PR TITLE
fix: Fixing NPE bug by adding to if clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ implementation 'com.google.cloud:google-cloud-bigquery'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigquery:2.40.0'
+implementation 'com.google.cloud:google-cloud-bigquery:2.40.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.40.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigquery" % "2.40.1"
 ```
 <!-- {x-version-update-end} -->
 
@@ -351,7 +351,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigquery/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquery.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.40.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.40.1
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -427,7 +427,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
     }
 
     if (!idRandom) {
-      if (createException instanceof BigQueryException && createException.getCause() != null) {
+      if (createException instanceof BigQueryException && createException.getCause() != null && createException.getCause().getMessage() != null) {
 
         /*GoogleJsonResponseException createExceptionCause =
         (GoogleJsonResponseException) createException.getCause();*/

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -427,7 +427,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
     }
 
     if (!idRandom) {
-      if (createException instanceof BigQueryException && createException.getCause() != null && createException.getCause().getMessage() != null) {
+      if (createException instanceof BigQueryException
+          && createException.getCause() != null
+          && createException.getCause().getMessage() != null) {
 
         /*GoogleJsonResponseException createExceptionCause =
         (GoogleJsonResponseException) createException.getCause();*/


### PR DESCRIPTION
Bug fix for NPE

NPE is...
```
java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
```

From my stacktrace...
```
java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
	at java.base/java.util.regex.Matcher.getTextLength(Matcher.java:1808)
	at java.base/java.util.regex.Matcher.reset(Matcher.java:461)
	at java.base/java.util.regex.Matcher.(Matcher.java:256)
	at java.base/java.util.regex.Pattern.matcher(Pattern.java:1180)
	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:436)
	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:363)
```

Looks like a bad null check to me
