### PR TITLE
docs: Update SimpleApp to explicitly set project id

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
@@ -20,6 +20,7 @@ package com.example.bigquery;
 // [START bigquery_simple_app_deps]
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.Job;

--- a/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
@@ -39,49 +39,53 @@ public class SimpleApp {
   }
 
   public static void simpleApp(String projectId) {
-    // [START bigquery_simple_app_client]
-    BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
-    // [END bigquery_simple_app_client]
-    // [START bigquery_simple_app_query]
-    QueryJobConfiguration queryConfig =
-        QueryJobConfiguration.newBuilder(
-                "SELECT CONCAT('https://stackoverflow.com/questions/', "
-                    + "CAST(id as STRING)) as url, view_count "
-                    + "FROM `bigquery-public-data.stackoverflow.posts_questions` "
-                    + "WHERE tags like '%google-bigquery%' "
-                    + "ORDER BY view_count DESC "
-                    + "LIMIT 10")
-            // Use standard SQL syntax for queries.
-            // See: https://cloud.google.com/bigquery/sql-reference/
-            .setUseLegacySql(false)
-            .build();
+    try {
+      // [START bigquery_simple_app_client]
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+      // [END bigquery_simple_app_client]
+      // [START bigquery_simple_app_query]
+      QueryJobConfiguration queryConfig =
+          QueryJobConfiguration.newBuilder(
+                  "SELECT CONCAT('https://stackoverflow.com/questions/', "
+                      + "CAST(id as STRING)) as url, view_count "
+                      + "FROM `bigquery-public-data.stackoverflow.posts_questions` "
+                      + "WHERE tags like '%google-bigquery%' "
+                      + "ORDER BY view_count DESC "
+                      + "LIMIT 10")
+              // Use standard SQL syntax for queries.
+              // See: https://cloud.google.com/bigquery/sql-reference/
+              .setUseLegacySql(false)
+              .build();
 
-    JobId jobId = JobId.newBuilder().setProject(projectId).build();
-    Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
+      JobId jobId = JobId.newBuilder().setProject(projectId).build();
+      Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
 
-    // Wait for the query to complete.
-    queryJob = queryJob.waitFor();
+      // Wait for the query to complete.
+      queryJob = queryJob.waitFor();
 
-    // Check for errors
-    if (queryJob == null) {
-      throw new RuntimeException("Job no longer exists");
-    } else if (queryJob.getStatus().getError() != null) {
-      // You can also look at queryJob.getStatus().getExecutionErrors() for all
-      // errors, not just the latest one.
-      throw new RuntimeException(queryJob.getStatus().getError().toString());
-    }
-    // [END bigquery_simple_app_query]
+      // Check for errors
+      if (queryJob == null) {
+        throw new RuntimeException("Job no longer exists");
+      } else if (queryJob.getStatus().getError() != null) {
+        // You can also look at queryJob.getStatus().getExecutionErrors() for all
+        // errors, not just the latest one.
+        throw new RuntimeException(queryJob.getStatus().getError().toString());
+      }
+      // [END bigquery_simple_app_query]
 
-    // [START bigquery_simple_app_print]
-    // Get the results.
-    TableResult result = queryJob.getQueryResults();
+      // [START bigquery_simple_app_print]
+      // Get the results.
+      TableResult result = queryJob.getQueryResults();
 
-    // Print all pages of the results.
-    for (FieldValueList row : result.iterateAll()) {
-      // String type
-      String url = row.get("url").getStringValue();
-      String viewCount = row.get("view_count").getStringValue();
-      System.out.printf("%s : %s views\n", url, viewCount);
+      // Print all pages of the results.
+      for (FieldValueList row : result.iterateAll()) {
+        // String type
+        String url = row.get("url").getStringValue();
+        String viewCount = row.get("view_count").getStringValue();
+        System.out.printf("%s : %s views\n", url, viewCount);
+      }
+    } catch (BigQueryException | InterruptedException e) {
+      System.out.println("Simple App failed due to error: \n" + e.toString());
     }
     // [END bigquery_simple_app_print]
   }

--- a/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
@@ -27,7 +27,6 @@ import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
-import java.util.UUID;
 
 // [END bigquery_simple_app_deps]
 

--- a/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
@@ -31,6 +31,7 @@ import com.google.cloud.bigquery.TableResult;
 // [END bigquery_simple_app_deps]
 
 public class SimpleApp {
+
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the app.
     String projectId = "MY_PROJECT_ID";
@@ -84,4 +85,5 @@ public class SimpleApp {
     }
     // [END bigquery_simple_app_print]
   }
+}
 // [END bigquery_simple_app_all]

--- a/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
+++ b/samples/snippets/src/main/java/com/example/bigquery/SimpleApp.java
@@ -33,6 +33,12 @@ import java.util.UUID;
 
 public class SimpleApp {
   public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the app.
+    String projectId = "MY_PROJECT_ID";
+    simpleApp(projectId);
+  }
+
+  public static void simpleApp(String projectId) {
     // [START bigquery_simple_app_client]
     BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
     // [END bigquery_simple_app_client]
@@ -50,8 +56,7 @@ public class SimpleApp {
             .setUseLegacySql(false)
             .build();
 
-    // Create a job ID so that we can safely retry.
-    JobId jobId = JobId.of(UUID.randomUUID().toString());
+    JobId jobId = JobId.newBuilder().setProject(projectId).build();
     Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
 
     // Wait for the query to complete.
@@ -80,5 +85,4 @@ public class SimpleApp {
     }
     // [END bigquery_simple_app_print]
   }
-}
 // [END bigquery_simple_app_all]

--- a/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
@@ -17,6 +17,7 @@
 package com.example.bigquery;
 
 import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
@@ -37,6 +37,12 @@ public class SimpleAppIT {
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
 
   @Before
   public void setUp() {
@@ -56,7 +62,7 @@ public class SimpleAppIT {
 
   @Test
   public void testQuickstart() throws Exception {
-    SimpleApp.main();
+    SimpleApp.simpleApp(PROJECT_ID);
     String got = bout.toString();
     assertThat(got).contains("https://stackoverflow.com/questions/");
   }

--- a/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
@@ -41,10 +41,12 @@ public class SimpleAppIT {
   private PrintStream originalPrintStream;
   private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
-  private static void requireEnvVar(String varName) {
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
     assertNotNull(
         "Environment variable " + varName + " is required to perform these tests.",
         System.getenv(varName));
+    return value;
   }
 
   @BeforeClass

--- a/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
+++ b/samples/snippets/src/test/java/com/example/bigquery/SimpleAppIT.java
@@ -40,6 +40,12 @@ public class SimpleAppIT {
   private PrintStream originalPrintStream;
   private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
   @BeforeClass
   public static void checkRequirements() {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");


### PR DESCRIPTION
When running in Google Cloud console, the default google cloud project might not be set leading to 404 errors. This update requires the reader to explicitly set the project value.

This also removes the explicit use of UUID to set jobId as the library now internally generates the value.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
