### PR TITLE
fix(test): Update schema for broken ConnImplBenchmark test

### DIFF
--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -81,8 +81,9 @@ public class ConnImplBenchmark {
     TableResult result = bigQuery.query(config);
     long hash = 0L;
     int cnt = 0;
-    System.out.print("\n Running");
+    System.out.println("\n Running");
     // iterate al the records and compute the hash
+    long lastTime = System.currentTimeMillis();
     for (FieldValueList row : result.iterateAll()) {
       hash +=
           row.get("vendor_id").getStringValue() == null
@@ -105,14 +106,6 @@ public class ConnImplBenchmark {
               ? 0
               : row.get("trip_distance").getDoubleValue();
       hash +=
-          row.get("pickup_longitude").getValue() == null
-              ? 0
-              : row.get("pickup_longitude").getDoubleValue();
-      hash +=
-          row.get("pickup_latitude").getValue() == null
-              ? 0
-              : row.get("pickup_latitude").getDoubleValue();
-      hash +=
           row.get("rate_code").getStringValue() == null
               ? 0
               : row.get("rate_code").getStringValue().hashCode();
@@ -125,22 +118,6 @@ public class ConnImplBenchmark {
               ? 0
               : row.get("payment_type").getStringValue().hashCode();
       hash +=
-          row.get("pickup_location_id").getStringValue() == null
-              ? 0
-              : row.get("pickup_location_id").getStringValue().hashCode();
-      hash +=
-          row.get("dropoff_location_id").getStringValue() == null
-              ? 0
-              : row.get("dropoff_location_id").getStringValue().hashCode();
-      hash +=
-          row.get("dropoff_longitude").getValue() == null
-              ? 0
-              : row.get("dropoff_longitude").getDoubleValue();
-      hash +=
-          row.get("dropoff_latitude").getValue() == null
-              ? 0
-              : row.get("dropoff_latitude").getDoubleValue();
-      hash +=
           row.get("fare_amount").getValue() == null ? 0 : row.get("fare_amount").getDoubleValue();
       hash += row.get("extra").getValue() == null ? 0 : row.get("extra").getDoubleValue();
       hash += row.get("mta_tax").getValue() == null ? 0 : row.get("mta_tax").getDoubleValue();
@@ -152,10 +129,31 @@ public class ConnImplBenchmark {
               ? 0
               : row.get("imp_surcharge").getDoubleValue();
       hash +=
+          row.get("airport_fee").getValue() == null ? 0 : row.get("airport_fee").getDoubleValue();
+      hash +=
           row.get("total_amount").getValue() == null ? 0 : row.get("total_amount").getDoubleValue();
+      hash +=
+          row.get("pickup_location_id").getStringValue() == null
+              ? 0
+              : row.get("pickup_location_id").getStringValue().hashCode();
+      hash +=
+          row.get("dropoff_location_id").getStringValue() == null
+              ? 0
+              : row.get("dropoff_location_id").getStringValue().hashCode();
+      hash +=
+          row.get("data_file_year").getValue() == null
+              ? 0
+              : row.get("data_file_year").getLongValue();
+      hash +=
+          row.get("data_file_month").getValue() == null
+              ? 0
+              : row.get("data_file_month").getLongValue();
 
-      if (++cnt % 100000 == 0) { // just to indicate the progress while long running benchmarks
-        System.out.print(".");
+      if (++cnt % 100_000 == 0) { // just to indicate the progress while long running benchmarks
+        long now = System.currentTimeMillis();
+        long duration = now - lastTime;
+        System.out.println("ROW " + cnt + " Time: " + duration + " ms");
+        lastTime = now;
       }
     }
     System.out.println(cnt + " records processed using bigquery.query");
@@ -207,7 +205,9 @@ public class ConnImplBenchmark {
     ResultSet rs = bigQueryResultSet.getResultSet();
     long hash = 0L;
     int cnt = 0;
-    System.out.print("\n Running");
+    System.out.println("\n Running");
+
+    long lastTime = System.currentTimeMillis();
     while (rs.next()) {
       hash += rs.getString("vendor_id") == null ? 0 : rs.getString("vendor_id").hashCode();
       hash +=
@@ -218,15 +218,11 @@ public class ConnImplBenchmark {
               : rs.getString("dropoff_datetime").hashCode();
       hash += rs.getLong("passenger_count");
       hash += rs.getDouble("trip_distance");
-      hash += rs.getDouble("pickup_longitude");
-      hash += rs.getDouble("pickup_latitude");
       hash += rs.getString("rate_code") == null ? 0 : rs.getString("rate_code").hashCode();
       hash +=
           rs.getString("store_and_fwd_flag") == null
               ? 0
               : rs.getString("store_and_fwd_flag").hashCode();
-      hash += rs.getDouble("dropoff_longitude");
-      hash += rs.getDouble("dropoff_latitude");
       hash += rs.getString("payment_type") == null ? 0 : rs.getString("payment_type").hashCode();
       hash += rs.getDouble("fare_amount");
       hash += rs.getDouble("extra");
@@ -234,6 +230,7 @@ public class ConnImplBenchmark {
       hash += rs.getDouble("tip_amount");
       hash += rs.getDouble("tolls_amount");
       hash += rs.getDouble("imp_surcharge");
+      hash += rs.getDouble("airport_fee");
       hash += rs.getDouble("total_amount");
       hash +=
           rs.getString("pickup_location_id") == null
@@ -243,8 +240,14 @@ public class ConnImplBenchmark {
           rs.getString("dropoff_location_id") == null
               ? 0
               : rs.getString("dropoff_location_id").hashCode();
-      if (++cnt % 100000 == 0) { // just to indicate the progress while long running benchmarks
-        System.out.print(".");
+      hash += rs.getLong("data_file_year");
+      hash += rs.getLong("data_file_month");
+
+      if (++cnt % 100_000 == 0) { // just to indicate the progress while long running benchmarks
+        long now = System.currentTimeMillis();
+        long duration = now - lastTime;
+        System.out.println("ROW " + cnt + " Time: " + duration + " ms");
+        lastTime = now;
       }
     }
     return hash;

--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.logging.Level;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -48,31 +49,19 @@ public class ConnImplBenchmark {
   public int rowLimit;
 
   private ConnectionSettings connectionSettingsReadAPIEnabled, connectionSettingsReadAPIDisabled;
-  private long numBuffRows = 100000L;
-  private final String DATASET = "new_york_taxi_trips";
   private final String QUERY =
       "SELECT * FROM bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2017 LIMIT %s";
-  public static final long NUM_PAGE_ROW_CNT_RATIO =
-      10; // ratio of [records in the current page :: total rows] to be met to use read API
-  public static final long NUM_MIN_RESULT_SIZE =
-      200000; // min number of records to use to ReadAPI with
 
   @Setup
   public void setUp() throws IOException {
     java.util.logging.Logger.getGlobal().setLevel(Level.ALL);
 
-    connectionSettingsReadAPIEnabled =
-        ConnectionSettings.newBuilder()
-            .setUseReadAPI(true) // enable read api
-            .build();
+    connectionSettingsReadAPIEnabled = ConnectionSettings.newBuilder().setUseReadAPI(true).build();
     connectionSettingsReadAPIDisabled =
-        ConnectionSettings.newBuilder()
-            .setUseReadAPI(false) // disable read api
-            .build();
+        ConnectionSettings.newBuilder().setUseReadAPI(false).build();
   }
 
   @Benchmark
-  // uses bigquery.query
   public void iterateRecordsWithBigQuery_Query(Blackhole blackhole) throws InterruptedException {
     String selectQuery = String.format(QUERY, rowLimit);
     BigQuery bigQuery = BigQueryOptions.getDefaultInstance().getService();
@@ -81,75 +70,31 @@ public class ConnImplBenchmark {
     TableResult result = bigQuery.query(config);
     long hash = 0L;
     int cnt = 0;
-    System.out.println("\n Running");
-    // iterate al the records and compute the hash
     long lastTime = System.currentTimeMillis();
+    System.out.println("\n Running");
     for (FieldValueList row : result.iterateAll()) {
-      hash +=
-          row.get("vendor_id").getStringValue() == null
-              ? 0
-              : row.get("vendor_id").getStringValue().hashCode();
-      hash +=
-          row.get("pickup_datetime").getStringValue() == null
-              ? 0
-              : row.get("pickup_datetime").getStringValue().hashCode();
-      hash +=
-          row.get("dropoff_datetime").getStringValue() == null
-              ? 0
-              : row.get("dropoff_datetime").getStringValue().hashCode();
-      hash +=
-          row.get("passenger_count").getValue() == null
-              ? 0
-              : row.get("passenger_count").getLongValue();
-      hash +=
-          row.get("trip_distance").getValue() == null
-              ? 0
-              : row.get("trip_distance").getDoubleValue();
-      hash +=
-          row.get("rate_code").getStringValue() == null
-              ? 0
-              : row.get("rate_code").getStringValue().hashCode();
-      hash +=
-          row.get("store_and_fwd_flag").getStringValue() == null
-              ? 0
-              : row.get("store_and_fwd_flag").getStringValue().hashCode();
-      hash +=
-          row.get("payment_type").getStringValue() == null
-              ? 0
-              : row.get("payment_type").getStringValue().hashCode();
-      hash +=
-          row.get("fare_amount").getValue() == null ? 0 : row.get("fare_amount").getDoubleValue();
-      hash += row.get("extra").getValue() == null ? 0 : row.get("extra").getDoubleValue();
-      hash += row.get("mta_tax").getValue() == null ? 0 : row.get("mta_tax").getDoubleValue();
-      hash += row.get("tip_amount").getValue() == null ? 0 : row.get("tip_amount").getDoubleValue();
-      hash +=
-          row.get("tolls_amount").getValue() == null ? 0 : row.get("tolls_amount").getDoubleValue();
-      hash +=
-          row.get("imp_surcharge").getValue() == null
-              ? 0
-              : row.get("imp_surcharge").getDoubleValue();
-      hash +=
-          row.get("airport_fee").getValue() == null ? 0 : row.get("airport_fee").getDoubleValue();
-      hash +=
-          row.get("total_amount").getValue() == null ? 0 : row.get("total_amount").getDoubleValue();
-      hash +=
-          row.get("pickup_location_id").getStringValue() == null
-              ? 0
-              : row.get("pickup_location_id").getStringValue().hashCode();
-      hash +=
-          row.get("dropoff_location_id").getStringValue() == null
-              ? 0
-              : row.get("dropoff_location_id").getStringValue().hashCode();
-      hash +=
-          row.get("data_file_year").getValue() == null
-              ? 0
-              : row.get("data_file_year").getLongValue();
-      hash +=
-          row.get("data_file_month").getValue() == null
-              ? 0
-              : row.get("data_file_month").getLongValue();
+      hash += computeHash(row.get("vendor_id"), FieldValue::getStringValue);
+      hash += computeHash(row.get("pickup_datetime"), FieldValue::getStringValue);
+      hash += computeHash(row.get("dropoff_datetime"), FieldValue::getStringValue);
+      hash += computeHash(row.get("passenger_count"), FieldValue::getLongValue);
+      hash += computeHash(row.get("trip_distance"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("rate_code"), FieldValue::getStringValue);
+      hash += computeHash(row.get("store_and_fwd_flag"), FieldValue::getStringValue);
+      hash += computeHash(row.get("payment_type"), FieldValue::getStringValue);
+      hash += computeHash(row.get("fare_amount"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("extra"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("mta_tax"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("tip_amount"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("tolls_amount"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("imp_surcharge"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("airport_fee"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("total_amount"), FieldValue::getDoubleValue);
+      hash += computeHash(row.get("pickup_location_id"), FieldValue::getStringValue);
+      hash += computeHash(row.get("dropoff_location_id"), FieldValue::getStringValue);
+      hash += computeHash(row.get("data_file_year"), FieldValue::getLongValue);
+      hash += computeHash(row.get("data_file_month"), FieldValue::getLongValue);
 
-      if (++cnt % 100_000 == 0) { // just to indicate the progress while long running benchmarks
+      if (++cnt % 100_000 == 0) {
         long now = System.currentTimeMillis();
         long duration = now - lastTime;
         System.out.println("ROW " + cnt + " Time: " + duration + " ms");
@@ -200,50 +145,35 @@ public class ConnImplBenchmark {
     blackhole.consume(hash);
   }
 
-  // Hashes all the 20 columns of all the rows
   private long getResultHash(BigQueryResult bigQueryResultSet) throws SQLException {
     ResultSet rs = bigQueryResultSet.getResultSet();
     long hash = 0L;
     int cnt = 0;
-    System.out.println("\n Running");
-
     long lastTime = System.currentTimeMillis();
+    System.out.println("\n Running");
     while (rs.next()) {
-      hash += rs.getString("vendor_id") == null ? 0 : rs.getString("vendor_id").hashCode();
-      hash +=
-          rs.getString("pickup_datetime") == null ? 0 : rs.getString("pickup_datetime").hashCode();
-      hash +=
-          rs.getString("dropoff_datetime") == null
-              ? 0
-              : rs.getString("dropoff_datetime").hashCode();
-      hash += rs.getLong("passenger_count");
-      hash += rs.getDouble("trip_distance");
-      hash += rs.getString("rate_code") == null ? 0 : rs.getString("rate_code").hashCode();
-      hash +=
-          rs.getString("store_and_fwd_flag") == null
-              ? 0
-              : rs.getString("store_and_fwd_flag").hashCode();
-      hash += rs.getString("payment_type") == null ? 0 : rs.getString("payment_type").hashCode();
-      hash += rs.getDouble("fare_amount");
-      hash += rs.getDouble("extra");
-      hash += rs.getDouble("mta_tax");
-      hash += rs.getDouble("tip_amount");
-      hash += rs.getDouble("tolls_amount");
-      hash += rs.getDouble("imp_surcharge");
-      hash += rs.getDouble("airport_fee");
-      hash += rs.getDouble("total_amount");
-      hash +=
-          rs.getString("pickup_location_id") == null
-              ? 0
-              : rs.getString("pickup_location_id").hashCode();
-      hash +=
-          rs.getString("dropoff_location_id") == null
-              ? 0
-              : rs.getString("dropoff_location_id").hashCode();
-      hash += rs.getLong("data_file_year");
-      hash += rs.getLong("data_file_month");
+      hash += computeHash(rs, "vendor_id", ResultSet::getString);
+      hash += computeHash(rs, "pickup_datetime", ResultSet::getString);
+      hash += computeHash(rs, "dropoff_datetime", ResultSet::getString);
+      hash += computeHash(rs, "passenger_count", ResultSet::getLong);
+      hash += computeHash(rs, "trip_distance", ResultSet::getDouble);
+      hash += computeHash(rs, "rate_code", ResultSet::getString);
+      hash += computeHash(rs, "store_and_fwd_flag", ResultSet::getString);
+      hash += computeHash(rs, "payment_type", ResultSet::getString);
+      hash += computeHash(rs, "fare_amount", ResultSet::getDouble);
+      hash += computeHash(rs, "extra", ResultSet::getDouble);
+      hash += computeHash(rs, "mta_tax", ResultSet::getDouble);
+      hash += computeHash(rs, "tip_amount", ResultSet::getDouble);
+      hash += computeHash(rs, "tolls_amount", ResultSet::getDouble);
+      hash += computeHash(rs, "imp_surcharge", ResultSet::getDouble);
+      hash += computeHash(rs, "airport_fee", ResultSet::getDouble);
+      hash += computeHash(rs, "total_amount", ResultSet::getDouble);
+      hash += computeHash(rs, "pickup_location_id", ResultSet::getString);
+      hash += computeHash(rs, "dropoff_location_id", ResultSet::getString);
+      hash += computeHash(rs, "data_file_year", ResultSet::getLong);
+      hash += computeHash(rs, "data_file_month", ResultSet::getLong);
 
-      if (++cnt % 100_000 == 0) { // just to indicate the progress while long running benchmarks
+      if (++cnt % 100_000 == 0) {
         long now = System.currentTimeMillis();
         long duration = now - lastTime;
         System.out.println("ROW " + cnt + " Time: " + duration + " ms");
@@ -251,6 +181,29 @@ public class ConnImplBenchmark {
       }
     }
     return hash;
+  }
+
+  private <T> long computeHash(
+      ResultSet rs, String columnName, SQLFunction<ResultSet, T> extractor) {
+    try {
+      T value = extractor.apply(rs, columnName);
+      return (value == null) ? 0 : value.hashCode();
+    } catch (SQLException e) {
+      return 0;
+    }
+  }
+
+  @FunctionalInterface
+  private interface SQLFunction<T, R> {
+    R apply(T t, String columnName) throws SQLException;
+  }
+
+  private <T> long computeHash(FieldValue fieldValue, Function<FieldValue, T> extractor) {
+    if (fieldValue == null || fieldValue.isNull()) {
+      return 0;
+    }
+    T value = extractor.apply(fieldValue);
+    return (value == null) ? 0 : value.hashCode();
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
I'm trying to use the `executeSelect` API and faced extremely slow reading.
I tried to use `ConnImplBenchmark` but noticed that the Shema was changed, and the test didn't work.

`bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2017`
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/4201e85d-34de-4734-beac-3133c922d7fa">
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/090b2e01-ebec-421a-b4ba-cf4cf8a8d72c">


Summary of Changes
Added Fields: airport_fee, data_file_year, data_file_month.
Removed Fields: dropoff_longitude, dropoff_latitude, pickup_longitude, pickup_latitude.

After fixing the test I can confirm that we have similar speed results for our use cases.
Reading 100_000 rows takes ~15-20 seconds, which is extremely slow.
```
 Running
ROW 100000 Time: 14978 ms
ROW 200000 Time: 16409 ms
ROW 300000 Time: 16966 ms
ROW 400000 Time: 15963 ms
ROW 500000 Time: 17480 ms
```

I'm not sure if there was any performance degradation recently since I can't find any expected numbers. It's hard to read this benchmark: https://cloud.google.com/blog/topics/developers-practitioners/introducing-executeselect-client-library-method-and-how-use-it/
According to this image, reading of 1_000_000 rows should take ~1sec
![image](https://github.com/user-attachments/assets/b9933b41-c7de-431c-97c2-be073f488e59)


That's what I've got on my machine:

```
Benchmark                                            (rowLimit)  Mode  Cnt       Score       Error  Units
ConnImplBenchmark.iterateRecordsUsingReadAPI             500000  avgt    3   76549.893 ± 14496.839  ms/op
ConnImplBenchmark.iterateRecordsUsingReadAPI            1000000  avgt    3  154957.127 ± 25916.110  ms/op
ConnImplBenchmark.iterateRecordsWithBigQuery_Query       500000  avgt    3   82508.807 ± 17930.275  ms/op
ConnImplBenchmark.iterateRecordsWithBigQuery_Query      1000000  avgt    3  165717.219 ± 86960.648  ms/op
ConnImplBenchmark.iterateRecordsWithoutUsingReadAPI      500000  avgt    3   84504.175 ± 36823.590  ms/op
ConnImplBenchmark.iterateRecordsWithoutUsingReadAPI     1000000  avgt    3  165142.367 ± 99899.991  ms/op
```

I've opened an issue: https://github.com/googleapis/java-bigquerystorage/issues/2764

