### PR TITLE
feat: introduce `java.time` methods and variables

### DIFF
--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -86,10 +86,6 @@
       <artifactId>gax</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.threeten</groupId>
-      <artifactId>threetenbp</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/google-cloud-bigquery/src/benchmark/java/com/google/cloud/bigquery/benchmark/Benchmark.java
+++ b/google-cloud-bigquery/src/benchmark/java/com/google/cloud/bigquery/benchmark/Benchmark.java
@@ -23,10 +23,10 @@ import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
 import java.io.FileInputStream;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
-import org.threeten.bp.Clock;
-import org.threeten.bp.Duration;
-import org.threeten.bp.Instant;
 
 public class Benchmark {
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -60,8 +60,6 @@ import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.threeten.bp.Instant;
-import org.threeten.bp.temporal.ChronoUnit;
 
 final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuery {
 
@@ -450,7 +448,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           long jobCreationTime = job.getStatistics().getCreationTime();
           long jobMinStaleTime = System.currentTimeMillis();
           long jobMaxStaleTime =
-              Instant.ofEpochMilli(jobMinStaleTime).minus(1, ChronoUnit.DAYS).toEpochMilli();
+              java.time.Instant.ofEpochMilli(jobMinStaleTime)
+                  .minus(1, java.time.temporal.ChronoUnit.DAYS)
+                  .toEpochMilli();
 
           // Only return the job if it has been created in the past 24 hours.
           // This is assuming any job older than 24 hours is a valid duplicate JobID

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryAlgorithm.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryAlgorithm.java
@@ -27,13 +27,13 @@ import com.google.api.gax.retrying.TimedRetryAlgorithm;
 import com.google.api.gax.retrying.TimedRetryAlgorithmWithContext;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import org.threeten.bp.Duration;
 
 public class BigQueryRetryAlgorithm<ResponseT> extends RetryAlgorithm<ResponseT> {
   private final BigQueryRetryConfig bigQueryRetryConfig;
@@ -67,7 +67,7 @@ public class BigQueryRetryAlgorithm<ResponseT> extends RetryAlgorithm<ResponseT>
     // Log retry info
     int attemptCount = nextAttemptSettings == null ? 0 : nextAttemptSettings.getAttemptCount();
     Duration retryDelay =
-        nextAttemptSettings == null ? Duration.ZERO : nextAttemptSettings.getRetryDelay();
+        nextAttemptSettings == null ? Duration.ZERO : nextAttemptSettings.getRetryDelayDuration();
     String errorMessage = previousThrowable != null ? previousThrowable.getMessage() : "";
 
     // Implementing shouldRetryBasedOnBigQueryRetryConfig so that we can retry exceptions based on

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
@@ -31,13 +31,13 @@ import com.google.cloud.bigquery.JobConfiguration.Type;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import org.threeten.bp.Duration;
 
 /**
  * A Google BigQuery Job.
@@ -52,20 +52,20 @@ public class Job extends JobInfo {
 
   private static final RetrySettings DEFAULT_JOB_WAIT_SETTINGS =
       RetrySettings.newBuilder()
-          .setTotalTimeout(Duration.ofHours(12L))
-          .setInitialRetryDelay(Duration.ofSeconds(1L))
+          .setTotalTimeoutDuration(Duration.ofHours(12L))
+          .setInitialRetryDelayDuration(Duration.ofSeconds(1L))
           .setRetryDelayMultiplier(2.0)
           .setJittered(true)
-          .setMaxRetryDelay(Duration.ofMinutes(1L))
+          .setMaxRetryDelayDuration(Duration.ofMinutes(1L))
           .build();
 
   static final RetrySettings DEFAULT_QUERY_JOB_WAIT_SETTINGS =
       RetrySettings.newBuilder()
-          .setTotalTimeout(Duration.ofHours(12L))
-          .setInitialRetryDelay(Duration.ofSeconds(3L))
+          .setTotalTimeoutDuration(Duration.ofHours(12L))
+          .setInitialRetryDelayDuration(Duration.ofSeconds(3L))
           .setRetryDelayMultiplier(1.0)
           .setJittered(true)
-          .setMaxRetryDelay(Duration.ofSeconds(3L))
+          .setMaxRetryDelayDuration(Duration.ofSeconds(3L))
           .build();
 
   static final QueryResultsOption[] DEFAULT_QUERY_WAIT_OPTIONS = {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
@@ -16,11 +16,12 @@
 
 package com.google.cloud.bigquery;
 
-import static org.threeten.bp.temporal.ChronoField.HOUR_OF_DAY;
-import static org.threeten.bp.temporal.ChronoField.MINUTE_OF_HOUR;
-import static org.threeten.bp.temporal.ChronoField.NANO_OF_SECOND;
-import static org.threeten.bp.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
+import com.google.api.core.ObsoleteApi;
 import com.google.api.services.bigquery.model.QueryParameterType;
 import com.google.api.services.bigquery.model.RangeValue;
 import com.google.auto.value.AutoValue;
@@ -33,17 +34,17 @@ import com.google.common.io.BaseEncoding;
 import com.google.gson.JsonObject;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneOffset;
-import org.threeten.bp.format.DateTimeFormatter;
-import org.threeten.bp.format.DateTimeFormatterBuilder;
-import org.threeten.bp.format.DateTimeParseException;
 import org.threeten.extra.PeriodDuration;
 
 /**
@@ -345,7 +346,11 @@ public abstract class QueryParameterValue implements Serializable {
     return of(value, StandardSQLTypeName.INTERVAL);
   }
 
-  /** Creates a {@code QueryParameterValue} object with a type of INTERVAL. */
+  /**
+   * Creates a {@code QueryParameterValue} object with a type of INTERVAL. This method is obsolete.
+   * Use {@link #interval(String)} instead.
+   */
+  @ObsoleteApi("Use interval(String) instead")
   public static QueryParameterValue interval(PeriodDuration value) {
     return of(value, StandardSQLTypeName.INTERVAL);
   }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelper.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelper.java
@@ -24,10 +24,10 @@ import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.threeten.bp.Duration;
 
 /**
  * Utility to create a remote BigQuery configuration for testing. BigQuery options can be obtained
@@ -144,13 +144,13 @@ public class RemoteBigQueryHelper {
     long totalTimeOut = 120000L;
     return RetrySettings.newBuilder()
         .setMaxAttempts(maxAttempts)
-        .setMaxRetryDelay(Duration.ofMillis(maxRetryDelay))
-        .setTotalTimeout(Duration.ofMillis(totalTimeOut))
-        .setInitialRetryDelay(Duration.ofMillis(initialRetryDelay))
+        .setMaxRetryDelayDuration(Duration.ofMillis(maxRetryDelay))
+        .setTotalTimeoutDuration(Duration.ofMillis(totalTimeOut))
+        .setInitialRetryDelayDuration(Duration.ofMillis(initialRetryDelay))
         .setRetryDelayMultiplier(retryDelayMultiplier)
-        .setInitialRpcTimeout(Duration.ofMillis(totalTimeOut))
+        .setInitialRpcTimeoutDuration(Duration.ofMillis(totalTimeOut))
         .setRpcTimeoutMultiplier(retryDelayMultiplier)
-        .setMaxRpcTimeout(Duration.ofMillis(totalTimeOut))
+        .setMaxRpcTimeoutDuration(Duration.ofMillis(totalTimeOut))
         .build();
   }
 

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/JobTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/JobTest.java
@@ -41,6 +41,7 @@ import com.google.cloud.bigquery.JobStatistics.CopyStatistics;
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics;
 import com.google.cloud.bigquery.JobStatus.State;
 import com.google.common.collect.ImmutableList;
+import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,7 +49,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
-import org.threeten.bp.Duration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JobTest {
@@ -83,8 +83,8 @@ public class JobTest {
 
   private static final RetryOption[] TEST_RETRY_OPTIONS =
       new RetryOption[] {
-        RetryOption.totalTimeout(Duration.ofSeconds(3)),
-        RetryOption.initialRetryDelay(Duration.ofMillis(1L)),
+        RetryOption.totalTimeoutDuration(Duration.ofSeconds(3)),
+        RetryOption.initialRetryDelayDuration(Duration.ofMillis(1L)),
         RetryOption.jittered(false),
         RetryOption.retryDelayMultiplier(1.0)
       };
@@ -402,7 +402,8 @@ public class JobTest {
     when(bigquery.getJob(JOB_INFO.getJobId(), expectedOptions)).thenReturn(runningJob);
     when(bigquery.getJob(JOB_INFO.getJobId(), expectedOptions)).thenReturn(runningJob);
     try {
-      job.waitFor(concat(TEST_RETRY_OPTIONS, RetryOption.totalTimeout(Duration.ofMillis(3))));
+      job.waitFor(
+          concat(TEST_RETRY_OPTIONS, RetryOption.totalTimeoutDuration(Duration.ofMillis(3))));
       Assert.fail();
     } catch (BigQueryException expected) {
       Assert.assertNotNull(expected.getMessage());

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryParameterValueTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryParameterValueTest.java
@@ -17,17 +17,21 @@
 package com.google.cloud.bigquery;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.threeten.bp.temporal.ChronoField.HOUR_OF_DAY;
-import static org.threeten.bp.temporal.ChronoField.MINUTE_OF_HOUR;
-import static org.threeten.bp.temporal.ChronoField.NANO_OF_SECOND;
-import static org.threeten.bp.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
 import com.google.api.services.bigquery.model.QueryParameterType;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.text.ParseException;
+import java.time.Instant;
 import java.time.Period;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -35,11 +39,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
-import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneOffset;
-import org.threeten.bp.format.DateTimeFormatter;
-import org.threeten.bp.format.DateTimeFormatterBuilder;
-import org.threeten.bp.jdk8.Jdk8Methods;
 import org.threeten.extra.PeriodDuration;
 
 public class QueryParameterValueTest {
@@ -338,8 +337,8 @@ public class QueryParameterValueTest {
   public void testTimestampWithFormatter() {
     long timestampInMicroseconds = 1571068536842L * 1000 + 123;
     long microseconds = 1_000_000;
-    long secs = Jdk8Methods.floorDiv(timestampInMicroseconds, microseconds);
-    int nano = (int) Jdk8Methods.floorMod(timestampInMicroseconds, microseconds) * 1000;
+    long secs = Math.floorDiv(timestampInMicroseconds, microseconds);
+    int nano = (int) Math.floorMod(timestampInMicroseconds, microseconds) * 1000;
     Instant instant = Instant.ofEpochSecond(secs, nano);
     String expected = TIMESTAMPFORMATTER.format(instant);
     assertThat(expected)

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -169,6 +169,7 @@ import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.Period;
@@ -195,7 +196,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.threeten.bp.Duration;
 import org.threeten.extra.PeriodDuration;
 
 public class ITBigQueryTest {
@@ -5347,7 +5347,7 @@ public class ITBigQueryTest {
     assertEquals(createdJob.getSelfLink(), remoteJob.getSelfLink());
     assertEquals(createdJob.getUserEmail(), remoteJob.getUserEmail());
 
-    Job completedJob = remoteJob.waitFor(RetryOption.totalTimeout(Duration.ofMinutes(1)));
+    Job completedJob = remoteJob.waitFor(RetryOption.totalTimeoutDuration(Duration.ofMinutes(1)));
     assertNotNull(completedJob);
     assertNull(completedJob.getStatus().getError());
     assertTrue(createdTable.delete());
@@ -5415,8 +5415,8 @@ public class ITBigQueryTest {
     assertNull(remoteJob.getUserEmail());
     Job completedJob =
         remoteJob.waitFor(
-            RetryOption.initialRetryDelay(Duration.ofSeconds(1)),
-            RetryOption.totalTimeout(Duration.ofMinutes(1)));
+            RetryOption.initialRetryDelayDuration(Duration.ofSeconds(1)),
+            RetryOption.totalTimeoutDuration(Duration.ofMinutes(1)));
     assertNotNull(completedJob);
     assertTrue(createdTable.delete());
     assertNull(completedJob.getStatus().getError());

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelperTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelperTest.java
@@ -25,12 +25,12 @@ import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.threeten.bp.Duration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteBigQueryHelperTest {
@@ -83,8 +83,8 @@ public class RemoteBigQueryHelperTest {
     assertEquals(60000, ((HttpTransportOptions) options.getTransportOptions()).getConnectTimeout());
     assertEquals(60000, ((HttpTransportOptions) options.getTransportOptions()).getReadTimeout());
     assertEquals(10, options.getRetrySettings().getMaxAttempts());
-    assertEquals(Duration.ofMillis(30000), options.getRetrySettings().getMaxRetryDelay());
-    assertEquals(Duration.ofMillis(120000), options.getRetrySettings().getTotalTimeout());
-    assertEquals(Duration.ofMillis(250), options.getRetrySettings().getInitialRetryDelay());
+    assertEquals(Duration.ofMillis(30000), options.getRetrySettings().getMaxRetryDelayDuration());
+    assertEquals(Duration.ofMillis(120000), options.getRetrySettings().getTotalTimeoutDuration());
+    assertEquals(Duration.ofMillis(250), options.getRetrySettings().getInitialRetryDelayDuration());
   }
 }


### PR DESCRIPTION
This PR introduces `java.time` alternatives to existing `org.threeten.bp.*` methods, as well as switching internal variables (if any) to `java.time`

The main constraint is to keep the changes backwards compatible, so for each existing threeten method "`method1(org.threeten.bp.Duration)`" we will add an alternative with a _Duration_ (or _Timestamp_ when applicable) suffix: "`method1Duration(java.time.Duration)`".

For most cases, the implementation will be held in the `java.time` method and the old threeten method will just delegate the call to it. However, for the case of abstract classes, the implementation will be kept in the threeten method to avoid breaking changes (i.e. users that already overloaded the method in their user code).