### PR TITLE
feat: Enable Lossless Timestamps in BQ java client lib

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1206,7 +1206,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           new PageImpl<>(
               new TableDataPageFetcher(tableId, schema, serviceOptions, cursor, pageOptionMap),
               cursor,
-              transformTableData(result.getRows(), schema)),
+              transformTableData(result.getRows(), schema, serviceOptions.getUseInt64Timestamps())),
           result.getTotalRows());
     } catch (RetryHelper.RetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
@@ -1214,7 +1214,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
   }
 
   private static Iterable<FieldValueList> transformTableData(
-      Iterable<TableRow> tableDataPb, final Schema schema) {
+      Iterable<TableRow> tableDataPb, final Schema schema, boolean useInt64Timestamps) {
     return ImmutableList.copyOf(
         Iterables.transform(
             tableDataPb != null ? tableDataPb : ImmutableList.<TableRow>of(),
@@ -1223,7 +1223,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
               @Override
               public FieldValueList apply(TableRow rowPb) {
-                return FieldValueList.fromPb(rowPb.getF(), fields);
+                return FieldValueList.fromPb(rowPb.getF(), fields, useInt64Timestamps);
               }
             }));
   }
@@ -1347,7 +1347,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
     // If all parameters passed in configuration are supported by the query() method on the backend,
     // put on fast path
-    QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);
+    QueryRequestInfo requestInfo = new QueryRequestInfo(configuration, getOptions().getUseInt64Timestamps());
     if (requestInfo.isFastQuerySupported(null)) {
       String projectId = getOptions().getProjectId();
       QueryRequest content = requestInfo.toPb();
@@ -1420,7 +1420,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                   // fetch next pages of results
                   new QueryPageFetcher(jobId, schema, getOptions(), cursor, optionMap(options)),
                   cursor,
-                  transformTableData(results.getRows(), schema)))
+                  transformTableData(results.getRows(), schema, getOptions().getUseInt64Timestamps())))
           .setJobId(jobId)
           .setQueryId(results.getQueryId())
           .build();
@@ -1433,7 +1433,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
             new PageImpl<>(
                 new TableDataPageFetcher(null, schema, getOptions(), null, optionMap(options)),
                 null,
-                transformTableData(results.getRows(), schema)))
+                transformTableData(results.getRows(), schema, getOptions().getUseInt64Timestamps())))
         // Return the JobID of the successful job
         .setJobId(
             results.getJobReference() != null ? JobId.fromPb(results.getJobReference()) : null)
@@ -1448,7 +1448,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
     // If all parameters passed in configuration are supported by the query() method on the backend,
     // put on fast path
-    QueryRequestInfo requestInfo = new QueryRequestInfo(configuration);
+    QueryRequestInfo requestInfo = new QueryRequestInfo(configuration, getOptions().getUseInt64Timestamps());
     if (requestInfo.isFastQuerySupported(jobId)) {
       // Be careful when setting the projectID in JobId, if a projectID is specified in the JobId,
       // the job created by the query method will use that project. This may cause the query to

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
@@ -38,6 +38,7 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
   private final String location;
   // set the option ThrowNotFound when you want to throw the exception when the value not found
   private boolean setThrowNotFound;
+  private boolean useInt64Timestamps;
   private String queryPreviewEnabled = System.getenv("QUERY_PREVIEW_ENABLED");
 
   public static class DefaultBigQueryFactory implements BigQueryFactory {
@@ -63,6 +64,7 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
   public static class Builder extends ServiceOptions.Builder<BigQuery, BigQueryOptions, Builder> {
 
     private String location;
+    private boolean useInt64Timestamps;
 
     private Builder() {}
 
@@ -84,6 +86,11 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
       return this;
     }
 
+    public Builder setUseInt64Timestamps(boolean useInt64Timestamps) {
+      this.useInt64Timestamps = useInt64Timestamps;
+      return this;
+    }
+
     @Override
     public BigQueryOptions build() {
       return new BigQueryOptions(this);
@@ -93,6 +100,7 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
   private BigQueryOptions(Builder builder) {
     super(BigQueryFactory.class, BigQueryRpcFactory.class, builder, new BigQueryDefaults());
     this.location = builder.location;
+    this.useInt64Timestamps = builder.useInt64Timestamps;
   }
 
   private static class BigQueryDefaults implements ServiceDefaults<BigQuery, BigQueryOptions> {
@@ -140,6 +148,10 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
     this.setThrowNotFound = setThrowNotFound;
   }
 
+  public void setUseInt64Timestamps(boolean useInt64Timestamps) {
+    this.useInt64Timestamps = useInt64Timestamps;
+  }
+
   @VisibleForTesting
   public void setQueryPreviewEnabled(String queryPreviewEnabled) {
     this.queryPreviewEnabled = queryPreviewEnabled;
@@ -147,6 +159,10 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
 
   public boolean getThrowNotFound() {
     return setThrowNotFound;
+  }
+
+  public boolean getUseInt64Timestamps() {
+    return useInt64Timestamps;
   }
 
   @SuppressWarnings("unchecked")

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java
@@ -26,6 +26,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.Instant;
@@ -50,6 +51,7 @@ public class FieldValue implements Serializable {
 
   private final Attribute attribute;
   private final Object value;
+  private final Boolean useInt64Timestamps;
 
   /** The field value's attribute, giving information on the field's content type. */
   public enum Attribute {
@@ -74,8 +76,13 @@ public class FieldValue implements Serializable {
   }
 
   private FieldValue(Attribute attribute, Object value) {
+    this(attribute, value, false);
+  }
+
+  private FieldValue(Attribute attribute, Object value, Boolean useInt64Timestamps) {
     this.attribute = checkNotNull(attribute);
     this.value = value;
+    this.useInt64Timestamps = useInt64Timestamps;
   }
 
   /**
@@ -105,6 +112,10 @@ public class FieldValue implements Serializable {
    */
   public Object getValue() {
     return value;
+  }
+
+  public Boolean getUseInt64Timestamps() {
+    return useInt64Timestamps;
   }
 
   /**
@@ -207,6 +218,9 @@ public class FieldValue implements Serializable {
    */
   @SuppressWarnings("unchecked")
   public long getTimestampValue() {
+    if (useInt64Timestamps) {
+      return new BigInteger(getStringValue()).longValue();
+    }
     // timestamps are encoded in the format 1408452095.22 where the integer part is seconds since
     // epoch (e.g. 1408452095.22 == 2014-08-19 07:41:35.220 -05:00)
     BigDecimal secondsWithMicro = new BigDecimal(getStringValue());
@@ -317,12 +331,13 @@ public class FieldValue implements Serializable {
     return MoreObjects.toStringHelper(this)
         .add("attribute", attribute)
         .add("value", value)
+        .add("useInt64Timestamps", useInt64Timestamps)
         .toString();
   }
 
   @Override
   public final int hashCode() {
-    return Objects.hash(attribute, value);
+    return Objects.hash(attribute, value, useInt64Timestamps);
   }
 
   @Override
@@ -334,7 +349,7 @@ public class FieldValue implements Serializable {
       return false;
     }
     FieldValue other = (FieldValue) obj;
-    return attribute == other.attribute && Objects.equals(value, other.value);
+    return attribute == other.attribute && Objects.equals(value, other.value) && Objects.equals(useInt64Timestamps, other.useInt64Timestamps);
   }
 
   /**
@@ -353,29 +368,33 @@ public class FieldValue implements Serializable {
    */
   @BetaApi
   public static FieldValue of(Attribute attribute, Object value) {
-    return new FieldValue(attribute, value);
+    return of(attribute, value, false);
+  }
+  @BetaApi
+  public static FieldValue of(Attribute attribute, Object value, Boolean useInt64Timestamps) {
+    return new FieldValue(attribute, value, useInt64Timestamps);
   }
 
   static FieldValue fromPb(Object cellPb) {
-    return fromPb(cellPb, null);
+    return fromPb(cellPb, null, false);
   }
 
   @SuppressWarnings("unchecked")
-  static FieldValue fromPb(Object cellPb, Field recordSchema) {
+  static FieldValue fromPb(Object cellPb, Field recordSchema, Boolean useInt64Timestamps) {
     if (Data.isNull(cellPb)) {
-      return FieldValue.of(Attribute.PRIMITIVE, null);
+      return FieldValue.of(Attribute.PRIMITIVE, null, useInt64Timestamps);
     }
     if (cellPb instanceof String) {
       if ((recordSchema != null)
           && (recordSchema.getType() == LegacySQLTypeName.RANGE)
           && (recordSchema.getRangeElementType() != null)) {
         return FieldValue.of(
-            Attribute.RANGE, Range.of((String) cellPb, recordSchema.getRangeElementType()));
+            Attribute.RANGE, Range.of((String) cellPb, recordSchema.getRangeElementType()), useInt64Timestamps);
       }
-      return FieldValue.of(Attribute.PRIMITIVE, cellPb);
+      return FieldValue.of(Attribute.PRIMITIVE, cellPb, useInt64Timestamps);
     }
     if (cellPb instanceof List) {
-      return FieldValue.of(Attribute.REPEATED, FieldValueList.fromPb((List<Object>) cellPb, null));
+      return FieldValue.of(Attribute.REPEATED, FieldValueList.fromPb((List<Object>) cellPb, null, useInt64Timestamps));
     }
     if (cellPb instanceof Map) {
       Map<String, Object> cellMapPb = (Map<String, Object>) cellPb;
@@ -383,12 +402,12 @@ public class FieldValue implements Serializable {
         FieldList subFieldsSchema = recordSchema != null ? recordSchema.getSubFields() : null;
         return FieldValue.of(
             Attribute.RECORD,
-            FieldValueList.fromPb((List<Object>) cellMapPb.get("f"), subFieldsSchema));
+            FieldValueList.fromPb((List<Object>) cellMapPb.get("f"), subFieldsSchema, useInt64Timestamps));
       }
       // This should never be the case when we are processing a first level table field (i.e. a
       // row's field, not a record sub-field)
       if (cellMapPb.containsKey("v")) {
-        return FieldValue.fromPb(cellMapPb.get("v"), recordSchema);
+        return FieldValue.fromPb(cellMapPb.get("v"), recordSchema, useInt64Timestamps);
       }
     }
     throw new IllegalArgumentException("Unexpected table cell format");

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValueList.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValueList.java
@@ -112,6 +112,10 @@ public class FieldValueList extends AbstractList<FieldValue> implements Serializ
   }
 
   static FieldValueList fromPb(List<?> rowPb, FieldList schema) {
+    return fromPb(rowPb, schema, false);
+  }
+
+  static FieldValueList fromPb(List<?> rowPb, FieldList schema, Boolean useInt64Timestamps) {
     List<FieldValue> row = new ArrayList<>(rowPb.size());
     if (schema != null) {
       if (schema.size() != rowPb.size()) {
@@ -120,11 +124,11 @@ public class FieldValueList extends AbstractList<FieldValue> implements Serializ
       Iterator<Field> schemaIter = schema.iterator();
       Iterator<?> rowPbIter = rowPb.iterator();
       while (rowPbIter.hasNext() && schemaIter.hasNext()) {
-        row.add(FieldValue.fromPb(rowPbIter.next(), schemaIter.next()));
+        row.add(FieldValue.fromPb(rowPbIter.next(), schemaIter.next(), useInt64Timestamps));
       }
     } else {
       for (Object cellPb : rowPb) {
-        row.add(FieldValue.fromPb(cellPb, null));
+        row.add(FieldValue.fromPb(cellPb, null, useInt64Timestamps));
       }
     }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -560,7 +560,6 @@ public final class QueryJobConfiguration extends JobConfiguration {
       this.useLegacySql = useLegacySql;
       return this;
     }
-
     /**
      * Limits the billing tier for this job. Queries that have resource usage beyond this tier will
      * fail (without incurring a charge). If unspecified, this will be set to your project default.

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryRequestInfo.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigquery;
 
+import com.google.api.services.bigquery.model.DataFormatOptions;
 import com.google.api.services.bigquery.model.QueryParameter;
 import com.google.api.services.bigquery.model.QueryRequest;
 import com.google.cloud.bigquery.QueryJobConfiguration.JobCreationMode;
@@ -42,8 +43,9 @@ final class QueryRequestInfo {
   private final Boolean useQueryCache;
   private final Boolean useLegacySql;
   private final JobCreationMode jobCreationMode;
+  private final DataFormatOptions formatOptions;
 
-  QueryRequestInfo(QueryJobConfiguration config) {
+  QueryRequestInfo(QueryJobConfiguration config, Boolean useInt64Timestamps) {
     this.config = config;
     this.connectionProperties = config.getConnectionProperties();
     this.defaultDataset = config.getDefaultDataset();
@@ -58,6 +60,7 @@ final class QueryRequestInfo {
     this.useLegacySql = config.useLegacySql();
     this.useQueryCache = config.useQueryCache();
     this.jobCreationMode = config.getJobCreationMode();
+    this.formatOptions = new DataFormatOptions().setUseInt64Timestamp(useInt64Timestamps);
   }
 
   boolean isFastQuerySupported(JobId jobId) {
@@ -122,6 +125,9 @@ final class QueryRequestInfo {
     if (jobCreationMode != null) {
       request.setJobCreationMode(jobCreationMode.toString());
     }
+    if (formatOptions != null) {
+      request.setFormatOptions(formatOptions);
+    }
     return request;
   }
 
@@ -141,6 +147,7 @@ final class QueryRequestInfo {
         .add("useQueryCache", useQueryCache)
         .add("useLegacySql", useLegacySql)
         .add("jobCreationMode", jobCreationMode)
+        .add("formatOptions", formatOptions.getUseInt64Timestamp())
         .toString();
   }
 
@@ -159,7 +166,8 @@ final class QueryRequestInfo {
         createSession,
         useQueryCache,
         useLegacySql,
-        jobCreationMode);
+        jobCreationMode,
+        formatOptions);
   }
 
   @Override

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/FieldValueListTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/FieldValueListTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.bigquery;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.api.client.util.Data;
@@ -72,6 +73,7 @@ public class FieldValueListTest {
   private final FieldValue floatFv = FieldValue.of(Attribute.PRIMITIVE, "1.5");
   private final FieldValue stringFv = FieldValue.of(Attribute.PRIMITIVE, "string");
   private final FieldValue timestampFv = FieldValue.of(Attribute.PRIMITIVE, "42");
+  private final FieldValue losslessTimestampFv = FieldValue.of(Attribute.PRIMITIVE, "42", true);
   private final FieldValue bytesFv = FieldValue.of(Attribute.PRIMITIVE, BYTES_BASE64);
   private final FieldValue nullFv = FieldValue.of(Attribute.PRIMITIVE, null);
   private final FieldValue repeatedFv =
@@ -122,6 +124,8 @@ public class FieldValueListTest {
     assertEquals(fieldValues, FieldValueList.fromPb(fieldValuesPb, schema));
     // Schema does not influence values equality
     assertEquals(fieldValues, FieldValueList.fromPb(fieldValuesPb, null));
+
+    assertNotEquals(fieldValues, FieldValueList.fromPb(fieldValuesPb, null, true));
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/FieldValueTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/FieldValueTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigquery;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -129,6 +130,22 @@ public class FieldValueTest {
     FieldValue fieldValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "-1.9954383398377106E10");
     long received = fieldValue.getTimestampValue();
     long expected = -19954383398377106L;
+    assertEquals(expected, received);
+  }
+
+  @Test
+  public void testInt64Timestamp() {
+    FieldValue lossyFieldValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "-1.9954383398377106E10");
+    long lossy = lossyFieldValue.getTimestampValue();
+
+    FieldValue losslessFieldValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "19954383398377106", true);
+    long lossless = losslessFieldValue.getTimestampValue();
+
+    assertNotEquals(lossy, lossless);
+
+    FieldValue fieldValue = FieldValue.of(FieldValue.Attribute.PRIMITIVE, "19954383398377106", true);
+    long received = fieldValue.getTimestampValue();
+    long expected = 19954383398377106L;
     assertEquals(expected, received);
   }
 

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryRequestInfoTest.java
@@ -18,6 +18,8 @@ package com.google.cloud.bigquery;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import com.google.api.services.bigquery.model.QueryRequest;
 import com.google.cloud.bigquery.JobInfo.CreateDisposition;
@@ -136,7 +138,7 @@ public class QueryRequestInfoTest {
           .setMaxResults(100L)
           .setJobCreationMode(jobCreationModeRequired)
           .build();
-  QueryRequestInfo REQUEST_INFO = new QueryRequestInfo(QUERY_JOB_CONFIGURATION);
+  QueryRequestInfo REQUEST_INFO = new QueryRequestInfo(QUERY_JOB_CONFIGURATION, false);
   private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION_SUPPORTED =
       QueryJobConfiguration.newBuilder(QUERY)
           .setUseQueryCache(USE_QUERY_CACHE)
@@ -150,7 +152,7 @@ public class QueryRequestInfoTest {
           .setCreateSession(CREATE_SESSION)
           .setMaxResults(100L)
           .build();
-  QueryRequestInfo REQUEST_INFO_SUPPORTED = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_SUPPORTED);
+  QueryRequestInfo REQUEST_INFO_SUPPORTED = new QueryRequestInfo(QUERY_JOB_CONFIGURATION_SUPPORTED, false);
 
   @Test
   public void testIsFastQuerySupported() {
@@ -171,8 +173,19 @@ public class QueryRequestInfoTest {
   @Test
   public void equalTo() {
     compareQueryRequestInfo(
-        new QueryRequestInfo(QUERY_JOB_CONFIGURATION_SUPPORTED), REQUEST_INFO_SUPPORTED);
-    compareQueryRequestInfo(new QueryRequestInfo(QUERY_JOB_CONFIGURATION), REQUEST_INFO);
+        new QueryRequestInfo(QUERY_JOB_CONFIGURATION_SUPPORTED, false), REQUEST_INFO_SUPPORTED);
+    compareQueryRequestInfo(new QueryRequestInfo(QUERY_JOB_CONFIGURATION, false), REQUEST_INFO);
+  }
+
+  @Test
+  public void testInt64Timestamp() {
+    QueryRequestInfo qri = new QueryRequestInfo(QUERY_JOB_CONFIGURATION, false);
+    QueryRequest qr = qri.toPb();
+    assertFalse(qr.getFormatOptions().getUseInt64Timestamp());
+
+    QueryRequestInfo qri2 = new QueryRequestInfo(QUERY_JOB_CONFIGURATION, true);
+    QueryRequest qr2 = qri2.toPb();
+    assertTrue(qr2.getFormatOptions().getUseInt64Timestamp());
   }
 
   /*
@@ -199,5 +212,6 @@ public class QueryRequestInfoTest {
     assertEquals(expectedQueryReq.getUseQueryCache(), actualQueryReq.getUseQueryCache());
     assertEquals(expectedQueryReq.getUseLegacySql(), actualQueryReq.getUseLegacySql());
     assertEquals(expectedQueryReq.get("jobCreationMode"), actualQueryReq.get("jobCreationMode"));
+    assertEquals(expectedQueryReq.getFormatOptions(), actualQueryReq.getFormatOptions());
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3235,6 +3235,26 @@ public class ITBigQueryTest {
     }
   }
 
+  @Test
+  public void testLosslessTimestamp() throws InterruptedException {
+    String query = "SELECT TIMESTAMP '2022-01-24T23:54:25.095574Z'";
+    long expectedTimestamp = 1643068465095574L;
+
+    bigquery.getOptions().setUseInt64Timestamps(true);
+
+    TableResult resultInteractive =
+        bigquery.query(
+            QueryJobConfiguration.newBuilder(query)
+                .setDefaultDataset(DatasetId.of(DATASET))
+                .build());
+    assertNotNull(resultInteractive.getJobId());
+    for (FieldValueList row : resultInteractive.getValues()) {
+      FieldValue timeStampCell = row.get(0);
+      assertEquals(expectedTimestamp, timeStampCell.getTimestampValue());
+    }
+    bigquery.getOptions().setUseInt64Timestamps(false);
+  }
+
   /* TODO(prasmish): replicate the entire test case for executeSelect */
   @Test
   public void testQuery() throws InterruptedException {


### PR DESCRIPTION
With discovery revision 20240124 or later, the BQ discovery document now properly exposes the API functionality to use lossless timestamps (DataFormatOptions.UseInt64Timestamp). This can be supplied as part of the jobs.query request, as well as passed as arguments to tabledata.list / jobs.getQueryResults.

This change enables the toggling of lossless timestamps in the java client library for BQ. The former format is still usable and is used by default. Users must opt in to use this feature.