### PR TITLE
feat(bigquery): support IAM conditions in datasets in Java client.

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
@@ -590,6 +590,68 @@ public final class Acl implements Serializable {
      */
     private final String location;
 
+    private static final long serialVersionUID = 7358264726377291156L;
+
+    static final class Builder {
+      private String expression;
+      private String title;
+      private String description;
+      private String location;
+
+      Builder() {}
+
+      Builder(Expr expr) {
+        this.expression = expr.expression;
+        this.title = expr.title;
+        this.description = expr.description;
+        this.location = expr.location;
+      }
+
+      Builder(com.google.api.services.bigquery.model.Expr bqExpr) {
+        this.expression = bqExpr.getExpression();
+        if (bqExpr.getTitle() != null) {
+          this.title = bqExpr.getTitle();
+        }
+        if (bqExpr.getDescription() != null) {
+          this.description = bqExpr.getDescription();
+        }
+        if (bqExpr.getLocation() != null) {
+          this.location = bqExpr.getLocation();
+        }
+      }
+
+      public Builder setExpression(String expression) {
+        this.expression = expression;
+        return this;
+      }
+
+      public Builder setTitle(String title) {
+        this.title = title;
+        return this;
+      }
+
+      public Builder setDescription(String description) {
+        this.description = description;
+        return this;
+      }
+
+      public Builder setLocation(String location) {
+        this.location = location;
+        return this;
+      }
+
+      public Expr build() {
+        return new Expr(this);
+      }
+    }
+
+    public Expr(Builder builder) {
+      this.expression = builder.expression;
+      this.title = builder.title;
+      this.description = builder.description;
+      this.location = builder.location;
+    }
+
     public Expr(String expression, String title, String description, String location) {
       this.expression = expression;
       this.title = title;
@@ -608,8 +670,11 @@ public final class Acl implements Serializable {
     }
 
     static Expr fromPb(com.google.api.services.bigquery.model.Expr bqExpr) {
-      return new Expr(
-          bqExpr.getExpression(), bqExpr.getTitle(), bqExpr.getDescription(), bqExpr.getLocation());
+      return new Builder(bqExpr).build();
+    }
+
+    public Builder toBuilder() {
+      return new Builder(this);
     }
 
     @Override

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
@@ -631,6 +631,11 @@ public final class Acl implements Serializable {
           && Objects.equals(this.description, other.description)
           && Objects.equals(this.location, other.location);
     }
+
+    @Override
+    public String toString() {
+      return toPb().toString();
+    }
   }
 
   private Acl(Entity entity, Role role) {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
@@ -21,9 +21,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.api.core.ApiFunction;
 import com.google.api.services.bigquery.model.Dataset.Access;
 import com.google.api.services.bigquery.model.DatasetAccessEntry;
+import com.google.api.services.bigquery.model.Expr;
 import com.google.cloud.StringEnumType;
 import com.google.cloud.StringEnumValue;
-import com.google.api.services.bigquery.model.Expr;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
@@ -570,25 +570,23 @@ public final class Acl implements Serializable {
     }
   }
 
-  /**
-   * Expr represents the conditional information related to dataset access policies.
-   */
+  /** Expr represents the conditional information related to dataset access policies. */
   public static final class Expr implements Serializable {
     // Textual representation of an expression in Common Expression Language syntax.
     private final String expression;
     /**
-     * Optional. Title for the expression, i.e. a short string describing
-     * its purpose. This can be used e.g. in UIs which allow to enter the expression.
+     * Optional. Title for the expression, i.e. a short string describing its purpose. This can be
+     * used e.g. in UIs which allow to enter the expression.
      */
     private final String title;
     /**
-     * Optional. Description of the expression. This is a longer text which
-     * describes the expression, e.g. when hovered over it in a UI.
+     * Optional. Description of the expression. This is a longer text which describes the
+     * expression, e.g. when hovered over it in a UI.
      */
     private final String description;
     /**
-     * Optional. String indicating the location of the expression for error
-     * reporting, e.g. a file name and a position in the file.
+     * Optional. String indicating the location of the expression for error reporting, e.g. a file
+     * name and a position in the file.
      */
     private final String location;
 
@@ -600,7 +598,8 @@ public final class Acl implements Serializable {
     }
 
     com.google.api.services.bigquery.model.Expr toPb() {
-      com.google.api.services.bigquery.model.Expr bqExpr = new com.google.api.services.bigquery.model.Expr();
+      com.google.api.services.bigquery.model.Expr bqExpr =
+          new com.google.api.services.bigquery.model.Expr();
       bqExpr.setExpression(this.expression);
       bqExpr.setTitle(this.title);
       bqExpr.setDescription(this.description);
@@ -609,7 +608,8 @@ public final class Acl implements Serializable {
     }
 
     static Expr fromPb(com.google.api.services.bigquery.model.Expr bqExpr) {
-      return new Expr(bqExpr.getExpression(), bqExpr.getTitle(), bqExpr.getDescription(), bqExpr.getLocation());
+      return new Expr(
+          bqExpr.getExpression(), bqExpr.getTitle(), bqExpr.getDescription(), bqExpr.getLocation());
     }
 
     static Expr defaultExpr() {
@@ -620,6 +620,7 @@ public final class Acl implements Serializable {
     public int hashCode() {
       return Objects.hash(expression, title, description, location);
     }
+
     @Override
     public boolean equals(Object obj) {
       if (this == obj) {
@@ -628,8 +629,11 @@ public final class Acl implements Serializable {
       if (obj == null || getClass() != obj.getClass()) {
         return false;
       }
-      final Expr other = (Expr)obj;
-      return Objects.equals(this.expression, other.expression) && Objects.equals(this.title, other.title) && Objects.equals(this.description, other.description) && Objects.equals(this.location, other.location);
+      final Expr other = (Expr) obj;
+      return Objects.equals(this.expression, other.expression)
+          && Objects.equals(this.title, other.title)
+          && Objects.equals(this.description, other.description)
+          && Objects.equals(this.location, other.location);
     }
   }
 
@@ -713,7 +717,9 @@ public final class Acl implements Serializable {
       return false;
     }
     final Acl other = (Acl) obj;
-    return Objects.equals(this.entity, other.entity) && Objects.equals(this.role, other.role) && Objects.equals(this.condition, other.condition);
+    return Objects.equals(this.entity, other.entity)
+        && Objects.equals(this.role, other.role)
+        && Objects.equals(this.condition, other.condition);
   }
 
   Access toPb() {
@@ -727,6 +733,8 @@ public final class Acl implements Serializable {
 
   static Acl fromPb(Access access) {
     return Acl.of(
-        Entity.fromPb(access), access.getRole() != null ? Role.valueOf(access.getRole()) : null, Expr.fromPb(access.getCondition()));
+        Entity.fromPb(access),
+        access.getRole() != null ? Role.valueOf(access.getRole()) : null,
+        Expr.fromPb(access.getCondition()));
   }
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
@@ -612,10 +612,6 @@ public final class Acl implements Serializable {
           bqExpr.getExpression(), bqExpr.getTitle(), bqExpr.getDescription(), bqExpr.getLocation());
     }
 
-    static Expr defaultExpr() {
-      return new Expr("", "", "", "");
-    }
-
     @Override
     public int hashCode() {
       return Objects.hash(expression, title, description, location);
@@ -638,7 +634,7 @@ public final class Acl implements Serializable {
   }
 
   private Acl(Entity entity, Role role) {
-    this(entity, role, Expr.defaultExpr());
+    this(entity, role, null);
   }
 
   private Acl(Entity entity, Role role, Expr condition) {
@@ -727,7 +723,9 @@ public final class Acl implements Serializable {
     if (role != null) {
       accessPb.setRole(role.name());
     }
-    accessPb.setCondition(condition.toPb());
+    if (condition != null) {
+      accessPb.setCondition(condition.toPb());
+    }
     return accessPb;
   }
 
@@ -735,6 +733,6 @@ public final class Acl implements Serializable {
     return Acl.of(
         Entity.fromPb(access),
         access.getRole() != null ? Role.valueOf(access.getRole()) : null,
-        Expr.fromPb(access.getCondition()));
+        access.getCondition() != null ? Expr.fromPb(access.getCondition()) : null);
   }
 }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -296,13 +296,13 @@ public interface BigQuery extends Service<BigQueryOptions> {
      * Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests
      * for conditional access policy binding in datasets must specify version 3. Datasets with no
      * conditional role bindings in access policy may specify any valid value or leave the field
-     * unset. This field will be mapped to
-     * <a href="https://cloud.google.com/iam/docs/policies#versions">IAM Policy version</a> and will
-     * be used to fetch the policy from IAM. If unset or if 0 or 1 the value is used for a dataset
-     * with conditional bindings, access entry with condition will have role string appended by
-     * 'withcond' string followed by a hash value. Please refer to
-     * <a href="https://cloud.google.com/iam/docs/troubleshooting-withcond">
-     * Troubleshooting withcond</a> for more details.
+     * unset. This field will be mapped to <a
+     * href="https://cloud.google.com/iam/docs/policies#versions">IAM Policy version</a> and will be
+     * used to fetch the policy from IAM. If unset or if 0 or 1 the value is used for a dataset with
+     * conditional bindings, access entry with condition will have role string appended by
+     * 'withcond' string followed by a hash value. Please refer to <a
+     * href="https://cloud.google.com/iam/docs/troubleshooting-withcond">Troubleshooting
+     * withcond</a> for more details.
      */
     public static DatasetOption accessPolicyVersion(Integer accessPolicyVersion) {
       return new DatasetOption(BigQueryRpc.Option.ACCESS_POLICY_VERSION, accessPolicyVersion);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -289,6 +289,10 @@ public interface BigQuery extends Service<BigQueryOptions> {
       return new DatasetOption(
           BigQueryRpc.Option.FIELDS, Helper.selector(DatasetField.REQUIRED_FIELDS, fields));
     }
+
+    public static DatasetOption accessPolicyVersion(Integer accessPolicyVersion) {
+      return new DatasetOption(BigQueryRpc.Option.ACCESS_POLICY_VERSION, accessPolicyVersion);
+    }
   }
 
   /** Class for specifying dataset delete options. */

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -290,6 +290,20 @@ public interface BigQuery extends Service<BigQueryOptions> {
           BigQueryRpc.Option.FIELDS, Helper.selector(DatasetField.REQUIRED_FIELDS, fields));
     }
 
+    /**
+     * Returns an option to specify the dataset's access policy version for conditional access. If
+     * this option is not provided the field remains unset and conditional access cannot be used.
+     * Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests
+     * for conditional access policy binding in datasets must specify version 3. Datasets with no
+     * conditional role bindings in access policy may specify any valid value or leave the field
+     * unset. This field will be mapped to
+     * <a href="https://cloud.google.com/iam/docs/policies#versions">IAM Policy version</a> and will
+     * be used to fetch the policy from IAM. If unset or if 0 or 1 the value is used for a dataset
+     * with conditional bindings, access entry with condition will have role string appended by
+     * 'withcond' string followed by a hash value. Please refer to
+     * <a href="https://cloud.google.com/iam/docs/troubleshooting-withcond">
+     * Troubleshooting withcond</a> for more details.
+     */
     public static DatasetOption accessPolicyVersion(Integer accessPolicyVersion) {
       return new DatasetOption(BigQueryRpc.Option.ACCESS_POLICY_VERSION, accessPolicyVersion);
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -261,10 +261,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
   public Dataset create(DatasetInfo datasetInfo, DatasetOption... options) {
     final com.google.api.services.bigquery.model.Dataset datasetPb =
         datasetInfo
-            .setProjectId(
-                Strings.isNullOrEmpty(datasetInfo.getDatasetId().getProject())
-                    ? getOptions().getProjectId()
-                    : datasetInfo.getDatasetId().getProject())
+            .setProjectId(Strings.isNullOrEmpty(datasetInfo.getDatasetId().getProject())
+                ? getOptions().getProjectId()
+                : datasetInfo.getDatasetId().getProject())
             .toPb();
     final Map<BigQueryRpc.Option, ?> optionsMap = optionMap(options);
     try {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -261,9 +261,10 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
   public Dataset create(DatasetInfo datasetInfo, DatasetOption... options) {
     final com.google.api.services.bigquery.model.Dataset datasetPb =
         datasetInfo
-            .setProjectId(Strings.isNullOrEmpty(datasetInfo.getDatasetId().getProject())
-                ? getOptions().getProjectId()
-                : datasetInfo.getDatasetId().getProject())
+            .setProjectId(
+                Strings.isNullOrEmpty(datasetInfo.getDatasetId().getProject())
+                    ? getOptions().getProjectId()
+                    : datasetInfo.getDatasetId().getProject())
             .toPb();
     final Map<BigQueryRpc.Option, ?> optionsMap = optionMap(options);
     try {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
@@ -59,7 +59,8 @@ public interface BigQueryRpc extends ServiceRpc {
     REQUESTED_POLICY_VERSION("requestedPolicyVersion"),
     TABLE_METADATA_VIEW("view"),
     RETRY_OPTIONS("retryOptions"),
-    BIGQUERY_RETRY_CONFIG("bigQueryRetryConfig");
+    BIGQUERY_RETRY_CONFIG("bigQueryRetryConfig"),
+    ACCESS_POLICY_VERSION("accessPolicyVersion");
 
     private final String value;
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -173,7 +173,22 @@ public class HttpBigQueryRpc implements BigQueryRpc {
   @Override
   public Dataset create(Dataset dataset, Map<Option, ?> options) {
     try {
+      Integer accessPolicyVersion = null;
+      for (Map.Entry<Option, ?> entry : options.entrySet()) {
+        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
+          accessPolicyVersion = (Integer)entry.getValue();
+        }
+      }
       validateRPC();
+      if (accessPolicyVersion != null) {
+        return bigquery
+            .datasets()
+            .insert(dataset.getDatasetReference().getProjectId(), dataset)
+            .setPrettyPrint(false)
+            .setFields(Option.FIELDS.getString(options))
+            .setAccessPolicyVersion(accessPolicyVersion)
+            .execute();
+      }
       return bigquery
           .datasets()
           .insert(dataset.getDatasetReference().getProjectId(), dataset)

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -176,7 +176,7 @@ public class HttpBigQueryRpc implements BigQueryRpc {
       Integer accessPolicyVersion = null;
       for (Map.Entry<Option, ?> entry : options.entrySet()) {
         if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
-          accessPolicyVersion = (Integer)entry.getValue();
+          accessPolicyVersion = (Integer) entry.getValue();
         }
       }
       validateRPC();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -130,6 +130,21 @@ public class HttpBigQueryRpc implements BigQueryRpc {
   public Dataset getDataset(String projectId, String datasetId, Map<Option, ?> options) {
     try {
       validateRPC();
+      Integer accessPolicyVersion = null;
+      for (Map.Entry<Option, ?> entry : options.entrySet()) {
+        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
+          accessPolicyVersion = (Integer) entry.getValue();
+        }
+      }
+      if (accessPolicyVersion != null) {
+        return bigquery
+            .datasets()
+            .get(projectId, datasetId)
+            .setFields(Option.FIELDS.getString(options))
+            .setPrettyPrint(false)
+            .setAccessPolicyVersion(accessPolicyVersion)
+            .execute();
+      }
       return bigquery
           .datasets()
           .get(projectId, datasetId)
@@ -173,13 +188,13 @@ public class HttpBigQueryRpc implements BigQueryRpc {
   @Override
   public Dataset create(Dataset dataset, Map<Option, ?> options) {
     try {
+      validateRPC();
       Integer accessPolicyVersion = null;
       for (Map.Entry<Option, ?> entry : options.entrySet()) {
         if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
           accessPolicyVersion = (Integer) entry.getValue();
         }
       }
-      validateRPC();
       if (accessPolicyVersion != null) {
         return bigquery
             .datasets()
@@ -291,7 +306,22 @@ public class HttpBigQueryRpc implements BigQueryRpc {
   public Dataset patch(Dataset dataset, Map<Option, ?> options) {
     try {
       validateRPC();
+      Integer accessPolicyVersion = null;
+      for (Map.Entry<Option, ?> entry : options.entrySet()) {
+        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
+          accessPolicyVersion = (Integer) entry.getValue();
+        }
+      }
       DatasetReference reference = dataset.getDatasetReference();
+      if (accessPolicyVersion != null) {
+        return bigquery
+            .datasets()
+            .patch(reference.getProjectId(), reference.getDatasetId(), dataset)
+            .setPrettyPrint(false)
+            .setFields(Option.FIELDS.getString(options))
+            .setAccessPolicyVersion(accessPolicyVersion)
+            .execute();
+      }
       return bigquery
           .datasets()
           .patch(reference.getProjectId(), reference.getDatasetId(), dataset)

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -136,21 +136,17 @@ public class HttpBigQueryRpc implements BigQueryRpc {
           accessPolicyVersion = (Integer) entry.getValue();
         }
       }
+
+      Bigquery.Datasets.Get bqGetRequest =
+          bigquery
+              .datasets()
+              .get(projectId, datasetId)
+              .setFields(Option.FIELDS.getString(options))
+              .setPrettyPrint(false);
       if (accessPolicyVersion != null) {
-        return bigquery
-            .datasets()
-            .get(projectId, datasetId)
-            .setFields(Option.FIELDS.getString(options))
-            .setPrettyPrint(false)
-            .setAccessPolicyVersion(accessPolicyVersion)
-            .execute();
+        bqGetRequest.setAccessPolicyVersion(accessPolicyVersion);
       }
-      return bigquery
-          .datasets()
-          .get(projectId, datasetId)
-          .setFields(Option.FIELDS.getString(options))
-          .setPrettyPrint(false)
-          .execute();
+      return bqGetRequest.execute();
     } catch (IOException ex) {
       BigQueryException serviceException = translate(ex);
       if (serviceException.getCode() == HTTP_NOT_FOUND) {
@@ -195,21 +191,16 @@ public class HttpBigQueryRpc implements BigQueryRpc {
           accessPolicyVersion = (Integer) entry.getValue();
         }
       }
+      Bigquery.Datasets.Insert bqCreateRequest =
+          bigquery
+              .datasets()
+              .insert(dataset.getDatasetReference().getProjectId(), dataset)
+              .setPrettyPrint(false)
+              .setFields(Option.FIELDS.getString(options));
       if (accessPolicyVersion != null) {
-        return bigquery
-            .datasets()
-            .insert(dataset.getDatasetReference().getProjectId(), dataset)
-            .setPrettyPrint(false)
-            .setFields(Option.FIELDS.getString(options))
-            .setAccessPolicyVersion(accessPolicyVersion)
-            .execute();
+        bqCreateRequest.setAccessPolicyVersion(accessPolicyVersion);
       }
-      return bigquery
-          .datasets()
-          .insert(dataset.getDatasetReference().getProjectId(), dataset)
-          .setPrettyPrint(false)
-          .setFields(Option.FIELDS.getString(options))
-          .execute();
+      return bqCreateRequest.execute();
     } catch (IOException ex) {
       throw translate(ex);
     }
@@ -313,21 +304,16 @@ public class HttpBigQueryRpc implements BigQueryRpc {
         }
       }
       DatasetReference reference = dataset.getDatasetReference();
+      Bigquery.Datasets.Patch bqPatchRequest =
+          bigquery
+              .datasets()
+              .patch(reference.getProjectId(), reference.getDatasetId(), dataset)
+              .setPrettyPrint(false)
+              .setFields(Option.FIELDS.getString(options));
       if (accessPolicyVersion != null) {
-        return bigquery
-            .datasets()
-            .patch(reference.getProjectId(), reference.getDatasetId(), dataset)
-            .setPrettyPrint(false)
-            .setFields(Option.FIELDS.getString(options))
-            .setAccessPolicyVersion(accessPolicyVersion)
-            .execute();
+        bqPatchRequest.setAccessPolicyVersion(accessPolicyVersion);
       }
-      return bigquery
-          .datasets()
-          .patch(reference.getProjectId(), reference.getDatasetId(), dataset)
-          .setPrettyPrint(false)
-          .setFields(Option.FIELDS.getString(options))
-          .execute();
+      return bqPatchRequest.execute();
     } catch (IOException ex) {
       throw translate(ex);
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -130,12 +130,6 @@ public class HttpBigQueryRpc implements BigQueryRpc {
   public Dataset getDataset(String projectId, String datasetId, Map<Option, ?> options) {
     try {
       validateRPC();
-      Integer accessPolicyVersion = null;
-      for (Map.Entry<Option, ?> entry : options.entrySet()) {
-        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
-          accessPolicyVersion = (Integer) entry.getValue();
-        }
-      }
 
       Bigquery.Datasets.Get bqGetRequest =
           bigquery
@@ -143,8 +137,10 @@ public class HttpBigQueryRpc implements BigQueryRpc {
               .get(projectId, datasetId)
               .setFields(Option.FIELDS.getString(options))
               .setPrettyPrint(false);
-      if (accessPolicyVersion != null) {
-        bqGetRequest.setAccessPolicyVersion(accessPolicyVersion);
+      for (Map.Entry<Option, ?> entry : options.entrySet()) {
+        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
+          bqGetRequest.setAccessPolicyVersion((Integer) entry.getValue());
+        }
       }
       return bqGetRequest.execute();
     } catch (IOException ex) {
@@ -185,20 +181,16 @@ public class HttpBigQueryRpc implements BigQueryRpc {
   public Dataset create(Dataset dataset, Map<Option, ?> options) {
     try {
       validateRPC();
-      Integer accessPolicyVersion = null;
-      for (Map.Entry<Option, ?> entry : options.entrySet()) {
-        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
-          accessPolicyVersion = (Integer) entry.getValue();
-        }
-      }
       Bigquery.Datasets.Insert bqCreateRequest =
           bigquery
               .datasets()
               .insert(dataset.getDatasetReference().getProjectId(), dataset)
               .setPrettyPrint(false)
               .setFields(Option.FIELDS.getString(options));
-      if (accessPolicyVersion != null) {
-        bqCreateRequest.setAccessPolicyVersion(accessPolicyVersion);
+      for (Map.Entry<Option, ?> entry : options.entrySet()) {
+        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
+          bqCreateRequest.setAccessPolicyVersion((Integer) entry.getValue());
+        }
       }
       return bqCreateRequest.execute();
     } catch (IOException ex) {
@@ -297,12 +289,6 @@ public class HttpBigQueryRpc implements BigQueryRpc {
   public Dataset patch(Dataset dataset, Map<Option, ?> options) {
     try {
       validateRPC();
-      Integer accessPolicyVersion = null;
-      for (Map.Entry<Option, ?> entry : options.entrySet()) {
-        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
-          accessPolicyVersion = (Integer) entry.getValue();
-        }
-      }
       DatasetReference reference = dataset.getDatasetReference();
       Bigquery.Datasets.Patch bqPatchRequest =
           bigquery
@@ -310,8 +296,10 @@ public class HttpBigQueryRpc implements BigQueryRpc {
               .patch(reference.getProjectId(), reference.getDatasetId(), dataset)
               .setPrettyPrint(false)
               .setFields(Option.FIELDS.getString(options));
-      if (accessPolicyVersion != null) {
-        bqPatchRequest.setAccessPolicyVersion(accessPolicyVersion);
+      for (Map.Entry<Option, ?> entry : options.entrySet()) {
+        if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
+          bqPatchRequest.setAccessPolicyVersion((Integer) entry.getValue());
+        }
       }
       return bqPatchRequest.execute();
     } catch (IOException ex) {

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/AclTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/AclTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.bigquery.Acl.DatasetAclEntity;
 import com.google.cloud.bigquery.Acl.Domain;
 import com.google.cloud.bigquery.Acl.Entity;
 import com.google.cloud.bigquery.Acl.Entity.Type;
+import com.google.cloud.bigquery.Acl.Expr;
 import com.google.cloud.bigquery.Acl.Group;
 import com.google.cloud.bigquery.Acl.IamMember;
 import com.google.cloud.bigquery.Acl.Role;
@@ -135,5 +136,14 @@ public class AclTest {
     acl = Acl.of(routine);
     assertEquals(routine, acl.getEntity());
     assertEquals(null, acl.getRole());
+  }
+
+  @Test
+  public void testOfWithCondition() {
+    Expr expr = new Expr("expression", "title", "description", "location");
+    Acl acl = Acl.of(Group.ofAllAuthenticatedUsers(), Role.READER, expr);
+    Dataset.Access pb = acl.toPb();
+    assertEquals(acl, Acl.fromPb(pb));
+    assertEquals(acl.getCondition(), expr);
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.Policy;
 import com.google.cloud.RetryOption;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.Tuple;
+import com.google.cloud.bigquery.BigQuery.DatasetOption;
 import com.google.cloud.bigquery.BigQuery.JobOption;
 import com.google.cloud.bigquery.BigQuery.QueryResultsOption;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
@@ -570,6 +571,20 @@ public class BigQueryImplTest {
     assertEquals(
         new Dataset(bigquery, new DatasetInfo.BuilderImpl(DATASET_INFO_WITH_PROJECT)), dataset);
     verify(bigqueryRpcMock).create(eq(DATASET_INFO_WITH_PROJECT.toPb()), capturedOptions.capture());
+  }
+
+  @Test
+  public void testCreateDatasetWithAccessPolicy() {
+    DatasetInfo datasetInfo = DATASET_INFO.setProjectId(OTHER_PROJECT);
+    DatasetOption datasetOption = DatasetOption.accessPolicyVersion(3);
+    when(bigqueryRpcMock.create(datasetInfo.toPb(), optionMap(datasetOption)))
+        .thenReturn(datasetInfo.toPb());
+    BigQueryOptions bigQueryOptions =
+        createBigQueryOptionsForProject(OTHER_PROJECT, rpcFactoryMock);
+    bigquery = bigQueryOptions.getService();
+    Dataset dataset = bigquery.create(datasetInfo, datasetOption);
+    assertEquals(new Dataset(bigquery, new DatasetInfo.BuilderImpl(datasetInfo)), dataset);
+    verify(bigqueryRpcMock).create(datasetInfo.toPb(), optionMap(datasetOption));
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -41,6 +41,8 @@ import com.google.cloud.Role;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigquery.Acl;
 import com.google.cloud.bigquery.Acl.DatasetAclEntity;
+import com.google.cloud.bigquery.Acl.Expr;
+import com.google.cloud.bigquery.Acl.User;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQuery.DatasetField;
@@ -1686,6 +1688,26 @@ public class ITBigQueryTest {
     assertEquals("und:ci", dataset.getDefaultCollation());
 
     RemoteBigQueryHelper.forceDelete(bigquery, collationDataset);
+  }
+
+  @Test
+  public void testCreateDatabaseWithAccessPolicyVersion() {
+    String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
+    User user = new User("Joe@example.com");
+    Acl.Role role = Acl.Role.OWNER;
+    Acl.Expr condition = new Expr("expression", "title", "description", "location");
+    Acl acl = Acl.of(user, role, condition);
+    DatasetInfo info =
+        DatasetInfo.newBuilder(accessPolicyDataset)
+            .setDescription(DESCRIPTION)
+            .setLabels(LABELS)
+            .setAcl(ImmutableList.of(acl))
+            .build();
+    DatasetOption datasetOption = DatasetOption.accessPolicyVersion(3);
+    Dataset dataset = bigquery.create(info, datasetOption);
+    assertNotNull(dataset);
+
+    RemoteBigQueryHelper.forceDelete(bigquery, accessPolicyDataset);
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -42,7 +42,6 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigquery.Acl;
 import com.google.cloud.bigquery.Acl.DatasetAclEntity;
 import com.google.cloud.bigquery.Acl.Expr;
-import com.google.cloud.bigquery.Acl.IamMember;
 import com.google.cloud.bigquery.Acl.User;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -213,6 +213,8 @@ public class ITBigQueryTest {
   private static final String MODEL_DATASET = RemoteBigQueryHelper.generateDatasetName();
   private static final String ROUTINE_DATASET = RemoteBigQueryHelper.generateDatasetName();
   private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
+  private static final String DEFAULT_USER_SERVICE_ACCOUNT =
+      "test-svc-bq-user@" + PROJECT_ID + ".iam.gserviceaccount.com";
   private static final String RANDOM_ID = UUID.randomUUID().toString().substring(0, 8);
   private static final String STORAGE_BILLING_MODEL = "LOGICAL";
   private static final Long MAX_TIME_TRAVEL_HOURS = 120L;
@@ -1224,7 +1226,7 @@ public class ITBigQueryTest {
   @Test
   public void testGetDatasetWithAccessPolicyVersion() {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
-    User user = new User("liamhuffman@google.com");
+    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
     Acl.Role role = Acl.Role.WRITER;
     Acl.Expr condition =
         new Expr(
@@ -1317,7 +1319,7 @@ public class ITBigQueryTest {
   }
 
   @Test
-  public void testUpdateDatabaseWithAccessPolicy() {
+  public void testUpdateDatabaseWithAccessPolicyVersion() {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
     Dataset dataset =
         bigquery.create(
@@ -1327,7 +1329,7 @@ public class ITBigQueryTest {
                 .build());
     assertThat(dataset).isNotNull();
 
-    User user = new User("liamhuffman@google.com");
+    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
     Acl.Role role = Acl.Role.WRITER;
     Acl.Expr condition =
         new Expr(
@@ -1763,7 +1765,7 @@ public class ITBigQueryTest {
   @Test
   public void testCreateDatabaseWithAccessPolicyVersion() {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
-    User user = new User("liamhuffman@google.com");
+    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
     Acl.Role role = Acl.Role.OWNER;
     Acl.Expr condition =
         new Expr(
@@ -1789,7 +1791,7 @@ public class ITBigQueryTest {
   @Test(expected = BigQueryException.class)
   public void testCreateDatabaseWithInvalidAccessPolicyVersion() {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
-    User user = new User("liamhuffman@google.com");
+    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
     Acl.Role role = Acl.Role.READER;
     Acl.Expr condition =
         new Expr(

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1230,9 +1230,9 @@ public class ITBigQueryTest {
     Acl.Role role = Acl.Role.WRITER;
     Acl.Expr condition =
         new Expr(
-            "request.time < timestamp('2030-01-01T00:00:00Z')",
+            "request.time > timestamp('2024-01-01T00:00:00Z')",
             "test condition",
-            "requests before the year 2030",
+            "requests after the year 2024",
             "location");
     Acl acl = Acl.of(user, role, condition);
     DatasetOption datasetOption = DatasetOption.accessPolicyVersion(3);
@@ -1246,10 +1246,21 @@ public class ITBigQueryTest {
             datasetOption);
     assertThat(dataset).isNotNull();
 
-    Dataset datasetClone = bigquery.getDataset(accessPolicyDataset, datasetOption);
-    assertNotNull(datasetClone);
-    assertEquals(dataset.getDescription(), datasetClone.getDescription());
-    assertNotNull(datasetClone.getCreationTime());
+    Dataset remoteDataset = bigquery.getDataset(accessPolicyDataset, datasetOption);
+    assertNotNull(remoteDataset);
+    assertEquals(dataset.getDescription(), remoteDataset.getDescription());
+    assertNotNull(remoteDataset.getCreationTime());
+
+    Acl remoteAclWithCond = null;
+    for (Acl remoteAcl : remoteDataset.getAcl()) {
+      if (remoteAcl.getCondition() != null) {
+        remoteAclWithCond = remoteAcl;
+      }
+    }
+    assertNotNull(remoteAclWithCond);
+    assertEquals(remoteAclWithCond.getCondition(), condition);
+
+    RemoteBigQueryHelper.forceDelete(bigquery, accessPolicyDataset);
   }
 
   @Test
@@ -1335,9 +1346,9 @@ public class ITBigQueryTest {
     Acl.Role role = Acl.Role.WRITER;
     Acl.Expr condition =
         new Expr(
-            "request.time < timestamp('2030-01-01T00:00:00Z')",
+            "request.time > timestamp('2024-01-01T00:00:00Z')",
             "test condition",
-            "requests before the year 2030",
+            "requests after the year 2024",
             "location");
     Acl acl = Acl.of(user, role, condition);
     List<Acl> acls = new ArrayList<>();
@@ -1357,6 +1368,15 @@ public class ITBigQueryTest {
     assertNotNull(updatedDataset);
     assertEquals(updatedDataset.getDescription(), "Updated Description");
     assertThat(updatedDataset.getLabels().isEmpty());
+
+    Acl updatedAclWithCond = null;
+    for (Acl updatedAcl : updatedDataset.getAcl()) {
+      if (updatedAcl.getCondition() != null) {
+        updatedAclWithCond = updatedAcl;
+      }
+    }
+    assertNotNull(updatedAclWithCond);
+    assertEquals(updatedAclWithCond.getCondition(), condition);
 
     RemoteBigQueryHelper.forceDelete(bigquery, accessPolicyDataset);
   }
@@ -1773,9 +1793,9 @@ public class ITBigQueryTest {
     Acl.Role role = Acl.Role.OWNER;
     Acl.Expr condition =
         new Expr(
-            "request.time < timestamp('2030-01-01T00:00:00Z')",
+            "request.time > timestamp('2024-01-01T00:00:00Z')",
             "test condition",
-            "requests before the year 2030",
+            "requests after the year 2024",
             "location");
     Acl acl = Acl.of(user, role, condition);
     DatasetInfo info =
@@ -1789,6 +1809,15 @@ public class ITBigQueryTest {
     assertNotNull(dataset);
     assertEquals(dataset.getDescription(), DESCRIPTION);
 
+    Acl remoteAclWithCond = null;
+    for (Acl remoteAcl : dataset.getAcl()) {
+      if (remoteAcl.getCondition() != null) {
+        remoteAclWithCond = remoteAcl;
+      }
+    }
+    assertNotNull(remoteAclWithCond);
+    assertEquals(remoteAclWithCond.getCondition(), condition);
+
     RemoteBigQueryHelper.forceDelete(bigquery, accessPolicyDataset);
   }
 
@@ -1801,9 +1830,9 @@ public class ITBigQueryTest {
     Acl.Role role = Acl.Role.READER;
     Acl.Expr condition =
         new Expr(
-            "request.time < timestamp('2030-01-01T00:00:00Z')",
+            "request.time > timestamp('2024-01-01T00:00:00Z')",
             "test condition",
-            "requests before the year 2030",
+            "requests after the year 2024",
             "location");
     Acl acl = Acl.of(user, role, condition);
     DatasetInfo info =

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -42,6 +42,7 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigquery.Acl;
 import com.google.cloud.bigquery.Acl.DatasetAclEntity;
 import com.google.cloud.bigquery.Acl.Expr;
+import com.google.cloud.bigquery.Acl.IamMember;
 import com.google.cloud.bigquery.Acl.User;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
@@ -213,8 +214,6 @@ public class ITBigQueryTest {
   private static final String MODEL_DATASET = RemoteBigQueryHelper.generateDatasetName();
   private static final String ROUTINE_DATASET = RemoteBigQueryHelper.generateDatasetName();
   private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
-  private static final String DEFAULT_USER_SERVICE_ACCOUNT =
-      "test-svc-bq-user@" + PROJECT_ID + ".iam.gserviceaccount.com";
   private static final String RANDOM_ID = UUID.randomUUID().toString().substring(0, 8);
   private static final String STORAGE_BILLING_MODEL = "LOGICAL";
   private static final Long MAX_TIME_TRAVEL_HOURS = 120L;
@@ -1224,9 +1223,11 @@ public class ITBigQueryTest {
   }
 
   @Test
-  public void testGetDatasetWithAccessPolicyVersion() {
+  public void testGetDatasetWithAccessPolicyVersion() throws IOException {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
-    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
+    ServiceAccountCredentials credentials =
+        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
+    User user = new User(credentials.getClientEmail());
     Acl.Role role = Acl.Role.WRITER;
     Acl.Expr condition =
         new Expr(
@@ -1319,8 +1320,10 @@ public class ITBigQueryTest {
   }
 
   @Test
-  public void testUpdateDatabaseWithAccessPolicyVersion() {
+  public void testUpdateDatabaseWithAccessPolicyVersion() throws IOException {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
+    ServiceAccountCredentials credentials =
+        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
     Dataset dataset =
         bigquery.create(
             DatasetInfo.newBuilder(accessPolicyDataset)
@@ -1329,7 +1332,7 @@ public class ITBigQueryTest {
                 .build());
     assertThat(dataset).isNotNull();
 
-    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
+    User user = new User(credentials.getClientEmail());
     Acl.Role role = Acl.Role.WRITER;
     Acl.Expr condition =
         new Expr(
@@ -1763,9 +1766,11 @@ public class ITBigQueryTest {
   }
 
   @Test
-  public void testCreateDatabaseWithAccessPolicyVersion() {
+  public void testCreateDatasetWithAccessPolicyVersion() throws IOException {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
-    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
+    ServiceAccountCredentials credentials =
+        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
+    User user = new User(credentials.getClientEmail());
     Acl.Role role = Acl.Role.OWNER;
     Acl.Expr condition =
         new Expr(
@@ -1789,9 +1794,11 @@ public class ITBigQueryTest {
   }
 
   @Test(expected = BigQueryException.class)
-  public void testCreateDatabaseWithInvalidAccessPolicyVersion() {
+  public void testCreateDatabaseWithInvalidAccessPolicyVersion() throws IOException {
     String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
-    User user = new User(DEFAULT_USER_SERVICE_ACCOUNT);
+    ServiceAccountCredentials credentials =
+        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
+    User user = new User(credentials.getClientEmail());
     Acl.Role role = Acl.Role.READER;
     Acl.Expr condition =
         new Expr(


### PR DESCRIPTION
This PR enables the use of IAM conditions when accessing a dataset through the create, update, and get API endpoints. The following changes are necessary:

- Add in a new `Expr` type in the `Acl` class for expressing the access conditions
- Create a new `DatasetOption` field to set the access policy version
- Set the access policy version before sending the rpc to the backend when applicable

Buganizer link: b/374156746