### PR TITLE
docs(bigquery): Add javadoc description of timestamp() parameter.

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
@@ -300,7 +300,11 @@ public abstract class QueryParameterValue implements Serializable {
     return of(value, StandardSQLTypeName.BYTES);
   }
 
-  /** Creates a {@code QueryParameterValue} object with a type of TIMESTAMP. */
+  /**
+   * Creates a {@code QueryParameterValue} object with a type of TIMESTAMP.
+   * @param value Microseconds since epoch, e.g. 1733945416000000 corresponds
+   * to 2024-12-11 19:30:16.929Z
+   * */
   public static QueryParameterValue timestamp(Long value) {
     return of(value, StandardSQLTypeName.TIMESTAMP);
   }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java
@@ -302,9 +302,10 @@ public abstract class QueryParameterValue implements Serializable {
 
   /**
    * Creates a {@code QueryParameterValue} object with a type of TIMESTAMP.
-   * @param value Microseconds since epoch, e.g. 1733945416000000 corresponds
-   * to 2024-12-11 19:30:16.929Z
-   * */
+   *
+   * @param value Microseconds since epoch, e.g. 1733945416000000 corresponds to 2024-12-11
+   *     19:30:16.929Z
+   */
   public static QueryParameterValue timestamp(Long value) {
     return of(value, StandardSQLTypeName.TIMESTAMP);
   }


### PR DESCRIPTION
The current input parameter for [timestamp()](https://github.com/googleapis/java-bigquery/blob/main/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryParameterValue.java#L304) is unclear regarding the expected format. This PR adds context to the javadocs for the function.

Fixes #2709 
