### PR TITLE
fix(test): Force usage of ReadAPI

### DIFF
--- a/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
+++ b/benchmark/src/main/java/com.google.cloud.bigquery/ConnImplBenchmark.java
@@ -56,9 +56,14 @@ public class ConnImplBenchmark {
   public void setUp() throws IOException {
     java.util.logging.Logger.getGlobal().setLevel(Level.ALL);
 
-    connectionSettingsReadAPIEnabled = ConnectionSettings.newBuilder().setUseReadAPI(true).build();
-    connectionSettingsReadAPIDisabled =
-        ConnectionSettings.newBuilder().setUseReadAPI(false).build();
+    connectionSettingsReadAPIEnabled = ConnectionSettings.newBuilder()
+            .setUseReadAPI(true)
+            .setMaxResults(500L)
+            .setJobTimeoutMs(Long.MAX_VALUE)
+            .build();
+    connectionSettingsReadAPIDisabled = ConnectionSettings.newBuilder()
+            .setUseReadAPI(false)
+            .build();
   }
 
   @Benchmark
@@ -153,8 +158,8 @@ public class ConnImplBenchmark {
     System.out.println("\n Running");
     while (rs.next()) {
       hash += computeHash(rs, "vendor_id", ResultSet::getString);
-      hash += computeHash(rs, "pickup_datetime", ResultSet::getString);
-      hash += computeHash(rs, "dropoff_datetime", ResultSet::getString);
+      hash += computeHash(rs, "pickup_datetime", ResultSet::getLong);
+      hash += computeHash(rs, "dropoff_datetime", ResultSet::getLong);
       hash += computeHash(rs, "passenger_count", ResultSet::getLong);
       hash += computeHash(rs, "trip_distance", ResultSet::getDouble);
       hash += computeHash(rs, "rate_code", ResultSet::getString);


### PR DESCRIPTION
Fixes https://github.com/googleapis/java-bigquerystorage/issues/2764

Related issue: https://github.com/googleapis/java-bigquery/pull/3574

SDK still uses the old API and just skips ReadAPI, even if it's enabled.
This happens because of this check: https://github.com/googleapis/java-bigquery/blob/08c483cb726bb36951680687260dd2d0371a9dc0/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java#L1201

In order to use ReadAPI, we need to add any of these configurations, for example, setJobTimeoutMs.
After this, we will see `Not Using Fast Query Path, using jobs.insert` and `Using BigQuery Read API` instead of `Using Fast Query Path`.

After enabling ReadAPI we've got 6-10x speed improvement:
```
Benchmark                                     (rowLimit)  Mode  Cnt       Score   Error  Units
ConnImplBenchmark.iterateRecordsUsingReadAPI      500000  avgt        16439.884          ms/op
ConnImplBenchmark.iterateRecordsUsingReadAPI     1000000  avgt        16005.065          ms/op
ConnImplBenchmark.iterateRecordsUsingReadAPI    10000000  avgt        74471.796          ms/op
ConnImplBenchmark.iterateRecordsUsingReadAPI    50000000  avgt       484732.516          ms/op
ConnImplBenchmark.iterateRecordsUsingReadAPI   100000000  avgt        48608.101          ms/op
```
