### PR TITLE
feat(bigquery): Support resource tags for datasets in java client

### DIFF
--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -134,4 +134,9 @@
     <className>com/google/cloud/bigquery/DatasetInfo*</className>
     <method>*setMaxTimeTravelHours(*)</method>
   </difference>
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/bigquery/DatasetInfo*</className>
+    <method>*setResourceTags(*)</method>
+  </difference>
   </differences>

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Dataset.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Dataset.java
@@ -171,6 +171,12 @@ public class Dataset extends DatasetInfo {
     }
 
     @Override
+    public Builder setResourceTags(Map<String, String> resourceTags) {
+      infoBuilder.setResourceTags(resourceTags);
+      return this;
+    }
+
+    @Override
     public Dataset build() {
       return new Dataset(bigquery, infoBuilder);
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/DatasetInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/DatasetInfo.java
@@ -76,7 +76,7 @@ public class DatasetInfo implements Serializable {
   private final ExternalDatasetReference externalDatasetReference;
   private final String storageBillingModel;
   private final Long maxTimeTravelHours;
-  private final Map<String, String> resourceTags;
+  private final Annotations resourceTags;
 
   /** A builder for {@code DatasetInfo} objects. */
   public abstract static class Builder {
@@ -222,7 +222,7 @@ public class DatasetInfo implements Serializable {
     private ExternalDatasetReference externalDatasetReference;
     private String storageBillingModel;
     private Long maxTimeTravelHours;
-    private Map<String, String> resourceTags;
+    private Annotations resourceTags = Annotations.ZERO;
 
     BuilderImpl() {}
 
@@ -286,9 +286,7 @@ public class DatasetInfo implements Serializable {
       }
       this.storageBillingModel = datasetPb.getStorageBillingModel();
       this.maxTimeTravelHours = datasetPb.getMaxTimeTravelHours();
-      if (datasetPb.getResourceTags() != null) {
-        this.resourceTags = datasetPb.getResourceTags();
-      }
+      this.resourceTags = Annotations.fromPb(datasetPb.getResourceTags());
     }
 
     @Override
@@ -409,7 +407,7 @@ public class DatasetInfo implements Serializable {
 
     @Override
     public Builder setResourceTags(Map<String, String> resourceTags) {
-      this.resourceTags = resourceTags;
+      this.resourceTags = Annotations.fromUser(resourceTags);
       return this;
     }
 
@@ -592,7 +590,7 @@ public class DatasetInfo implements Serializable {
    * @return value or {@code null} for none
    */
   public Map<String, String> getResourceTags() {
-    return resourceTags;
+    return resourceTags.userMap();
   }
 
   /**
@@ -717,9 +715,7 @@ public class DatasetInfo implements Serializable {
     if (maxTimeTravelHours != null) {
       datasetPb.setMaxTimeTravelHours(maxTimeTravelHours);
     }
-    if (resourceTags != null) {
-      datasetPb.setResourceTags(resourceTags);
-    }
+    datasetPb.setResourceTags(resourceTags.toPb());
     return datasetPb;
   }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/DatasetInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/DatasetInfo.java
@@ -76,6 +76,7 @@ public class DatasetInfo implements Serializable {
   private final ExternalDatasetReference externalDatasetReference;
   private final String storageBillingModel;
   private final Long maxTimeTravelHours;
+  private final Map<String, String> resourceTags;
 
   /** A builder for {@code DatasetInfo} objects. */
   public abstract static class Builder {
@@ -184,6 +185,19 @@ public class DatasetInfo implements Serializable {
      */
     public abstract Builder setDefaultCollation(String defaultCollation);
 
+    /**
+     * Optional. The <a href="https://cloud.google.com/bigquery/docs/tags">tags</a> attached to this
+     * dataset. Tag keys are globally unique. Tag key is expected to be in the namespaced format,
+     * for example "123456789012/environment" where 123456789012 is the ID of the parent
+     * organization or project resource for this tag key. Tag value is expected to be the short
+     * name, for example "Production".
+     *
+     * @see <a href="https://cloud.google.com/iam/docs/tags-access-control#definitions">Tag
+     *     definitions</a> for more details.
+     * @param resourceTags resourceTags or {@code null} for none
+     */
+    public abstract Builder setResourceTags(Map<String, String> resourceTags);
+
     /** Creates a {@code DatasetInfo} object. */
     public abstract DatasetInfo build();
   }
@@ -208,6 +222,7 @@ public class DatasetInfo implements Serializable {
     private ExternalDatasetReference externalDatasetReference;
     private String storageBillingModel;
     private Long maxTimeTravelHours;
+    private Map<String, String> resourceTags;
 
     BuilderImpl() {}
 
@@ -230,6 +245,7 @@ public class DatasetInfo implements Serializable {
       this.externalDatasetReference = datasetInfo.externalDatasetReference;
       this.storageBillingModel = datasetInfo.storageBillingModel;
       this.maxTimeTravelHours = datasetInfo.maxTimeTravelHours;
+      this.resourceTags = datasetInfo.resourceTags;
     }
 
     BuilderImpl(com.google.api.services.bigquery.model.Dataset datasetPb) {
@@ -270,6 +286,9 @@ public class DatasetInfo implements Serializable {
       }
       this.storageBillingModel = datasetPb.getStorageBillingModel();
       this.maxTimeTravelHours = datasetPb.getMaxTimeTravelHours();
+      if (datasetPb.getResourceTags() != null) {
+        this.resourceTags = datasetPb.getResourceTags();
+      }
     }
 
     @Override
@@ -389,6 +408,12 @@ public class DatasetInfo implements Serializable {
     }
 
     @Override
+    public Builder setResourceTags(Map<String, String> resourceTags) {
+      this.resourceTags = resourceTags;
+      return this;
+    }
+
+    @Override
     public DatasetInfo build() {
       return new DatasetInfo(this);
     }
@@ -413,6 +438,7 @@ public class DatasetInfo implements Serializable {
     externalDatasetReference = builder.externalDatasetReference;
     storageBillingModel = builder.storageBillingModel;
     maxTimeTravelHours = builder.maxTimeTravelHours;
+    resourceTags = builder.resourceTags;
   }
 
   /** Returns the dataset identity. */
@@ -555,6 +581,21 @@ public class DatasetInfo implements Serializable {
   }
 
   /**
+   * Optional. The <a href="https://cloud.google.com/bigquery/docs/tags">tags</a> attached to this
+   * dataset. Tag keys are globally unique. Tag key is expected to be in the namespaced format, for
+   * example "123456789012/environment" where 123456789012 is the ID of the parent organization or
+   * project resource for this tag key. Tag value is expected to be the short name, for example
+   * "Production".
+   *
+   * @see <a href="https://cloud.google.com/iam/docs/tags-access-control#definitions">Tag
+   *     definitions</a> for more details.
+   * @return value or {@code null} for none
+   */
+  public Map<String, String> getResourceTags() {
+    return resourceTags;
+  }
+
+  /**
    * Returns information about the external metadata storage where the dataset is defined. Filled
    * out when the dataset type is EXTERNAL.
    */
@@ -588,6 +629,7 @@ public class DatasetInfo implements Serializable {
         .add("externalDatasetReference", externalDatasetReference)
         .add("storageBillingModel", storageBillingModel)
         .add("maxTimeTravelHours", maxTimeTravelHours)
+        .add("resourceTags", resourceTags)
         .toString();
   }
 
@@ -674,6 +716,9 @@ public class DatasetInfo implements Serializable {
     }
     if (maxTimeTravelHours != null) {
       datasetPb.setMaxTimeTravelHours(maxTimeTravelHours);
+    }
+    if (resourceTags != null) {
+      datasetPb.setResourceTags(resourceTags);
     }
     return datasetPb;
   }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetInfoTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetInfoTest.java
@@ -62,6 +62,10 @@ public class DatasetInfoTest {
   private static final String STORAGE_BILLING_MODEL = "LOGICAL";
   private static final Long MAX_TIME_TRAVEL_HOURS_5_DAYS = 120L;
   private static final Long MAX_TIME_TRAVEL_HOURS_7_DAYS = 168L;
+  private static final Map<String, String> RESOURCE_TAGS =
+      ImmutableMap.of(
+          "example-key1", "example-value1",
+          "example-key2", "example-value2");
 
   private static final ExternalDatasetReference EXTERNAL_DATASET_REFERENCE =
       ExternalDatasetReference.newBuilder()
@@ -85,6 +89,7 @@ public class DatasetInfoTest {
           .setDefaultPartitionExpirationMs(DEFAULT_PARTITION__EXPIRATION)
           .setStorageBillingModel(STORAGE_BILLING_MODEL)
           .setMaxTimeTravelHours(MAX_TIME_TRAVEL_HOURS_7_DAYS)
+          .setResourceTags(RESOURCE_TAGS)
           .build();
   private static final DatasetInfo DATASET_INFO_COMPLETE =
       DATASET_INFO
@@ -183,6 +188,7 @@ public class DatasetInfoTest {
     assertEquals(
         MAX_TIME_TRAVEL_HOURS_5_DAYS,
         DATASET_INFO_WITH_MAX_TIME_TRAVEL_5_DAYS.getMaxTimeTravelHours());
+    assertEquals(RESOURCE_TAGS, DATASET_INFO.getResourceTags());
   }
 
   @Test
@@ -272,5 +278,6 @@ public class DatasetInfoTest {
     assertEquals(expected.getExternalDatasetReference(), value.getExternalDatasetReference());
     assertEquals(expected.getStorageBillingModel(), value.getStorageBillingModel());
     assertEquals(expected.getMaxTimeTravelHours(), value.getMaxTimeTravelHours());
+    assertEquals(expected.getResourceTags(), value.getResourceTags());
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetTest.java
@@ -68,6 +68,10 @@ public class DatasetTest {
   private static final Field FIELD = Field.of("FieldName", LegacySQLTypeName.INTEGER);
   private static final String STORAGE_BILLING_MODEL = "LOGICAL";
   private static final Long MAX_TIME_TRAVEL_HOURS = 168L;
+  private static final Map<String, String> RESOURCE_TAGS =
+      ImmutableMap.of(
+          "example-key1", "example-value1",
+          "example-key2", "example-value2");
   private static final StandardTableDefinition TABLE_DEFINITION =
       StandardTableDefinition.of(Schema.of(FIELD));
   private static final ViewDefinition VIEW_DEFINITION = ViewDefinition.of("QUERY");
@@ -124,6 +128,7 @@ public class DatasetTest {
             .setLabels(LABELS)
             .setStorageBillingModel(STORAGE_BILLING_MODEL)
             .setMaxTimeTravelHours(MAX_TIME_TRAVEL_HOURS)
+            .setResourceTags(RESOURCE_TAGS)
             .build();
     assertEquals(DATASET_ID, builtDataset.getDatasetId());
     assertEquals(ACCESS_RULES, builtDataset.getAcl());
@@ -139,6 +144,7 @@ public class DatasetTest {
     assertEquals(LABELS, builtDataset.getLabels());
     assertEquals(STORAGE_BILLING_MODEL, builtDataset.getStorageBillingModel());
     assertEquals(MAX_TIME_TRAVEL_HOURS, builtDataset.getMaxTimeTravelHours());
+    assertEquals(RESOURCE_TAGS, builtDataset.getResourceTags());
   }
 
   @Test
@@ -348,6 +354,7 @@ public class DatasetTest {
             .setExternalDatasetReference(EXTERNAL_DATASET_REFERENCE)
             .setStorageBillingModel(STORAGE_BILLING_MODEL)
             .setMaxTimeTravelHours(MAX_TIME_TRAVEL_HOURS)
+            .setResourceTags(RESOURCE_TAGS)
             .build();
     assertEquals(
         EXTERNAL_DATASET_REFERENCE,
@@ -379,5 +386,6 @@ public class DatasetTest {
     assertEquals(expected.getExternalDatasetReference(), value.getExternalDatasetReference());
     assertEquals(expected.getStorageBillingModel(), value.getStorageBillingModel());
     assertEquals(expected.getMaxTimeTravelHours(), value.getMaxTimeTravelHours());
+    assertEquals(expected.getResourceTags(), value.getResourceTags());
   }
 }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1295,25 +1295,35 @@ public class ITBigQueryTest {
                 .setLabels(updateLabels)
                 .setStorageBillingModel("LOGICAL")
                 .setMaxTimeTravelHours(MAX_TIME_TRAVEL_HOURS)
-                .setResourceTags(RESOURCE_TAGS)
+                // .setResourceTags(RESOURCE_TAGS)
                 .build());
     assertThat(updatedDataset.getDescription()).isEqualTo("Updated Description");
     assertThat(updatedDataset.getLabels()).containsExactly("x", "y");
     assertThat(updatedDataset.getStorageBillingModel()).isEqualTo("LOGICAL");
     assertThat(updatedDataset.getMaxTimeTravelHours()).isEqualTo(MAX_TIME_TRAVEL_HOURS);
-    assertThat(updatedDataset.getResourceTags()).isEqualTo(RESOURCE_TAGS);
+    // assertThat(updatedDataset.getResourceTags()).isEqualTo(RESOURCE_TAGS);
 
     updatedDataset = bigquery.update(updatedDataset.toBuilder().setLabels(null).build());
     assertThat(updatedDataset.getLabels()).isEmpty();
     assertThat(dataset.delete()).isTrue();
   }
 
+  /*
   @Test
-  public void testUpdateDatasetResourceTags() {
+  public void testUpdateDatasetResourceTags() throws IOException {
+    String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
+    ServiceAccountCredentials credentials =
+        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
+
+    User user = new User(credentials.getClientEmail());
+    Acl.Role role = Acl.Role.OWNER;
+    Acl acl = Acl.of(user, role);
+
     Dataset dataset =
         bigquery.create(
             DatasetInfo.newBuilder(OTHER_DATASET)
                 .setDescription("Some Description")
+                .setAcl(ImmutableList.of(acl))
                 .setLabels(Collections.singletonMap("a", "b"))
                 .setResourceTags(RESOURCE_TAGS)
                 .build());
@@ -1336,6 +1346,7 @@ public class ITBigQueryTest {
 
     assertThat(updatedDataset.delete()).isTrue();
   }
+  */
 
   @Test
   public void testUpdateDatasetWithSelectedFields() {
@@ -1805,10 +1816,17 @@ public class ITBigQueryTest {
 
   @Test
   public void testCreateDatasetWithSpecificResourceTags() {
+    ServiceAccountCredentials credentials =
+        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
+    User user = new User(credentials.getClientEmail());
+    Acl.Role role = Acl.Role.OWNER;
+    Acl acl = Acl.of(user, role);
+
     String resourceTaggedDataset = RemoteBigQueryHelper.generateDatasetName();
     DatasetInfo info =
         DatasetInfo.newBuilder(resourceTaggedDataset)
             .setDescription(DESCRIPTION)
+            .setAcl(ImmutableList.of(acl))
             .setLabels(LABELS)
             .setResourceTags(RESOURCE_TAGS)
             .build();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -223,10 +223,6 @@ public class ITBigQueryTest {
       ImmutableMap.of(
           "example-label1", "example-value1",
           "example-label2", "example-value2");
-  private static final Map<String, String> RESOURCE_TAGS =
-      ImmutableMap.of(
-          PROJECT_ID + "/example-key1", "example-value1",
-          PROJECT_ID + "/example-key2", "example-value2");
   private static final Field TIMESTAMP_FIELD_SCHEMA =
       Field.newBuilder("TimestampField", LegacySQLTypeName.TIMESTAMP)
           .setMode(Field.Mode.NULLABLE)
@@ -1282,7 +1278,6 @@ public class ITBigQueryTest {
     assertThat(dataset.getLabels()).containsExactly("a", "b");
     assertThat(dataset.getStorageBillingModel()).isNull();
     assertThat(dataset.getMaxTimeTravelHours()).isNull();
-    assertThat(dataset.getResourceTags()).isNull();
 
     Map<String, String> updateLabels = new HashMap<>();
     updateLabels.put("x", "y");
@@ -1295,58 +1290,16 @@ public class ITBigQueryTest {
                 .setLabels(updateLabels)
                 .setStorageBillingModel("LOGICAL")
                 .setMaxTimeTravelHours(MAX_TIME_TRAVEL_HOURS)
-                // .setResourceTags(RESOURCE_TAGS)
                 .build());
     assertThat(updatedDataset.getDescription()).isEqualTo("Updated Description");
     assertThat(updatedDataset.getLabels()).containsExactly("x", "y");
     assertThat(updatedDataset.getStorageBillingModel()).isEqualTo("LOGICAL");
     assertThat(updatedDataset.getMaxTimeTravelHours()).isEqualTo(MAX_TIME_TRAVEL_HOURS);
-    // assertThat(updatedDataset.getResourceTags()).isEqualTo(RESOURCE_TAGS);
 
     updatedDataset = bigquery.update(updatedDataset.toBuilder().setLabels(null).build());
     assertThat(updatedDataset.getLabels()).isEmpty();
     assertThat(dataset.delete()).isTrue();
   }
-
-  /*
-  @Test
-  public void testUpdateDatasetResourceTags() throws IOException {
-    String accessPolicyDataset = RemoteBigQueryHelper.generateDatasetName();
-    ServiceAccountCredentials credentials =
-        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
-
-    User user = new User(credentials.getClientEmail());
-    Acl.Role role = Acl.Role.OWNER;
-    Acl acl = Acl.of(user, role);
-
-    Dataset dataset =
-        bigquery.create(
-            DatasetInfo.newBuilder(OTHER_DATASET)
-                .setDescription("Some Description")
-                .setAcl(ImmutableList.of(acl))
-                .setLabels(Collections.singletonMap("a", "b"))
-                .setResourceTags(RESOURCE_TAGS)
-                .build());
-
-    Map<String, String> updatedResourceTags =
-        ImmutableMap.of(
-            PROJECT_ID + "updated-key1",
-            "updated-value1",
-            PROJECT_ID + "updated-key2",
-            "updated-value2");
-
-    Dataset updatedDataset =
-        bigquery.update(dataset.toBuilder().setResourceTags(updatedResourceTags).build());
-    assertThat(updatedDataset.getResourceTags()).isEqualTo(updatedResourceTags);
-
-    assertThat(updatedResourceTags.remove(PROJECT_ID + "updated-key2")).isNotNull();
-    updatedDataset =
-        bigquery.update(dataset.toBuilder().setResourceTags(updatedResourceTags).build());
-    assertThat(updatedDataset.getResourceTags()).isEqualTo(updatedResourceTags);
-
-    assertThat(updatedDataset.delete()).isTrue();
-  }
-  */
 
   @Test
   public void testUpdateDatasetWithSelectedFields() {
@@ -1812,30 +1765,6 @@ public class ITBigQueryTest {
     assertEquals(MAX_TIME_TRAVEL_HOURS_DEFAULT, dataset.getMaxTimeTravelHours());
 
     RemoteBigQueryHelper.forceDelete(bigquery, timeTravelDataset);
-  }
-
-  @Test
-  public void testCreateDatasetWithSpecificResourceTags() throws IOException {
-    ServiceAccountCredentials credentials =
-        (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
-    User user = new User(credentials.getClientEmail());
-    Acl.Role role = Acl.Role.OWNER;
-    Acl acl = Acl.of(user, role);
-
-    String resourceTaggedDataset = RemoteBigQueryHelper.generateDatasetName();
-    DatasetInfo info =
-        DatasetInfo.newBuilder(resourceTaggedDataset)
-            .setDescription(DESCRIPTION)
-            .setAcl(ImmutableList.of(acl))
-            .setLabels(LABELS)
-            .setResourceTags(RESOURCE_TAGS)
-            .build();
-    bigquery.create(info);
-
-    Dataset dataset = bigquery.getDataset(DatasetId.of(resourceTaggedDataset));
-    assertEquals(RESOURCE_TAGS, dataset.getResourceTags());
-
-    RemoteBigQueryHelper.forceDelete(bigquery, resourceTaggedDataset);
   }
 
   @Test

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1815,7 +1815,7 @@ public class ITBigQueryTest {
   }
 
   @Test
-  public void testCreateDatasetWithSpecificResourceTags() {
+  public void testCreateDatasetWithSpecificResourceTags() throws IOException {
     ServiceAccountCredentials credentials =
         (ServiceAccountCredentials) GoogleCredentials.getApplicationDefault();
     User user = new User(credentials.getClientEmail());


### PR DESCRIPTION
This change implements the resource tag feature from bigquery in the java client library. See doc [here](https://docs.google.com/document/d/1NWeFYxTV_kjlVaLdwbV0OVOOX-kfKa3aUtgEyq3bAb8/edit?tab=t.0#heading=h.kpi8g41cg5iw)

Integration tests for this change can be found at this [PR draft](https://github.com/googleapis/java-bigquery/pull/3652). These tests fail in the kokoro environment because we are not able to able to add [tags](https://pantheon.corp.google.com/iam-admin/tags?inv=1&invt=Abn_Ng&project=cloud-devrel-kokoro-resources&supportedpurview=organizationId) to the project due to lack of permissions. The integration tests pass in my personal cloud project as I have permissions to create and edit [tags](https://pantheon.corp.google.com/iam-admin/tags?inv=1&invt=Abn_Ng&project=liamhuffman-testing) in my own project.
