### PR TITLE
#3672 Using in-memory Job.Status.State - if present - for Job.isDone() calls first to avoid remote calls

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
@@ -193,8 +193,17 @@ public class Job extends JobInfo {
    */
   public boolean isDone() {
     checkNotDryRun("isDone");
+    // check the known state in-memory as it might already contain that it has been finished
+    if (hasDoneState()) {
+      return true;
+    }
+    // refresh the state from BQ to check if it has finished since the current in-memory state has been fetched
     Job job = bigquery.getJob(getJobId(), JobOption.fields(BigQuery.JobField.STATUS));
-    return job == null || JobStatus.State.DONE.equals(job.getStatus().getState());
+    return job == null || job.hasDoneState();
+}
+
+private boolean hasDoneState() {
+    return getStatus() != null && JobStatus.State.DONE.equals(getStatus().getState());
   }
 
   /** See {@link #waitFor(BigQueryRetryConfig, RetryOption...)} */


### PR DESCRIPTION

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #3672  ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
