### PR TITLE
chore: format source code with google-java-format 1.25.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 17
     - run: java -version
     - run: .kokoro/build.sh
       env:

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -52,7 +52,7 @@ test)
     RETURN_CODE=$?
     ;;
 lint)
-    mvn com.coveo:fmt-maven-plugin:check -B -ntp
+    mvn com.spotify.fmt:fmt-maven-plugin:check -B -ntp
     RETURN_CODE=$?
     ;;
 javadoc)

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Acl.java
@@ -92,7 +92,9 @@ public final class Acl implements Serializable {
       return type.valueOf(constant);
     }
 
-    /** @return Return the known values for Role. */
+    /**
+     * @return Return the known values for Role.
+     */
     public static Role[] values() {
       return type.values();
     }
@@ -184,7 +186,9 @@ public final class Acl implements Serializable {
       this.targetTypes = targetTypes;
     }
 
-    /** @return Returns DatasetAclEntity's identity. */
+    /**
+     * @return Returns DatasetAclEntity's identity.
+     */
     public DatasetId getId() {
       return id;
     }
@@ -240,7 +244,9 @@ public final class Acl implements Serializable {
       this.domain = domain;
     }
 
-    /** @return Returns the domain name. */
+    /**
+     * @return Returns the domain name.
+     */
     public String getDomain() {
       return domain;
     }
@@ -348,22 +354,30 @@ public final class Acl implements Serializable {
       }
     }
 
-    /** @return Returns a Group entity representing all project's owners. */
+    /**
+     * @return Returns a Group entity representing all project's owners.
+     */
     public static Group ofProjectOwners() {
       return new Group(PROJECT_OWNERS);
     }
 
-    /** @return Returns a Group entity representing all project's readers. */
+    /**
+     * @return Returns a Group entity representing all project's readers.
+     */
     public static Group ofProjectReaders() {
       return new Group(PROJECT_READERS);
     }
 
-    /** @return Returns a Group entity representing all project's writers. */
+    /**
+     * @return Returns a Group entity representing all project's writers.
+     */
     public static Group ofProjectWriters() {
       return new Group(PROJECT_WRITERS);
     }
 
-    /** @return Returns a Group entity representing all BigQuery authenticated users. */
+    /**
+     * @return Returns a Group entity representing all BigQuery authenticated users.
+     */
     public static Group ofAllAuthenticatedUsers() {
       return new Group(ALL_AUTHENTICATED_USERS);
     }
@@ -385,7 +399,9 @@ public final class Acl implements Serializable {
       this.email = email;
     }
 
-    /** @return Returns user's email. */
+    /**
+     * @return Returns user's email.
+     */
     public String getEmail() {
       return email;
     }
@@ -437,7 +453,9 @@ public final class Acl implements Serializable {
       this.id = id;
     }
 
-    /** @return Returns table's identity. */
+    /**
+     * @return Returns table's identity.
+     */
     public TableId getId() {
       return id;
     }
@@ -489,7 +507,9 @@ public final class Acl implements Serializable {
       this.id = id;
     }
 
-    /** @return Returns routine's identity. */
+    /**
+     * @return Returns routine's identity.
+     */
     public RoutineId getId() {
       return id;
     }
@@ -537,7 +557,9 @@ public final class Acl implements Serializable {
       this.iamMember = iamMember;
     }
 
-    /** @return Returns iamMember. */
+    /**
+     * @return Returns iamMember.
+     */
     public String getIamMember() {
       return iamMember;
     }
@@ -574,16 +596,19 @@ public final class Acl implements Serializable {
   public static final class Expr implements Serializable {
     // Textual representation of an expression in Common Expression Language syntax.
     private final String expression;
+
     /**
      * Optional. Title for the expression, i.e. a short string describing its purpose. This can be
      * used e.g. in UIs which allow to enter the expression.
      */
     private final String title;
+
     /**
      * Optional. Description of the expression. This is a longer text which describes the
      * expression, e.g. when hovered over it in a UI.
      */
     private final String description;
+
     /**
      * Optional. String indicating the location of the expression for error reporting, e.g. a file
      * name and a position in the file.
@@ -713,16 +738,23 @@ public final class Acl implements Serializable {
     this.condition = condition;
   }
 
-  /** @return Returns the entity for this ACL. */
+  /**
+   * @return Returns the entity for this ACL.
+   */
   public Entity getEntity() {
     return entity;
   }
 
-  /** @return Returns the role specified by this ACL. */
+  /**
+   * @return Returns the role specified by this ACL.
+   */
   public Role getRole() {
     return role;
   }
-  /** @return Returns the condition specified by this ACL. */
+
+  /**
+   * @return Returns the condition specified by this ACL.
+   */
   public Expr getCondition() {
     return condition;
   }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -1409,8 +1409,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
     if (getOptions().isQueryPreviewEnabled()) {
       configuration =
-          configuration
-              .toBuilder()
+          configuration.toBuilder()
               .setJobCreationMode(JobCreationMode.JOB_CREATION_OPTIONAL)
               .build();
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -135,6 +135,7 @@ class ConnectionImpl implements Connection {
         ? 20000
         : Math.min(connectionSettings.getNumBufferedRows() * 2, 100000));
   }
+
   /**
    * Cancel method shutdowns the pageFetcher and producerWorker threads gracefully using interrupt.
    * The pageFetcher threat will not request for any subsequent threads after interrupting and
@@ -263,6 +264,7 @@ class ConnectionImpl implements Connection {
       throw new BigQuerySQLException(e.getMessage(), e, e.getErrors());
     }
   }
+
   /**
    * Execute a SQL statement that returns a single ResultSet and returns a ListenableFuture to
    * process the response asynchronously.
@@ -527,6 +529,7 @@ class ConnectionImpl implements Connection {
         queryStatistics.getSessionInfo() == null ? null : queryStatistics.getSessionInfo();
     return new BigQueryResultStatsImpl(queryStatistics, sessionInfo);
   }
+
   /* This method processed the first page of GetQueryResultsResponse and then it uses tabledata.list */
   @VisibleForTesting
   BigQueryResult tableDataList(GetQueryResultsResponse firstPage, JobId jobId) {
@@ -1109,7 +1112,9 @@ class ConnectionImpl implements Connection {
       loader = new VectorLoader(root);
     }
 
-    /** @param batch object returned from the ReadRowsResponse. */
+    /**
+     * @param batch object returned from the ReadRowsResponse.
+     */
     private void processRows(
         ArrowRecordBatch batch, BlockingQueue<BigQueryResultImpl.Row> buffer, Schema schema)
         throws IOException { // deserialize the values and consume the hash of the values
@@ -1166,6 +1171,7 @@ class ConnectionImpl implements Connection {
       allocator.close();
     }
   }
+
   /*Returns just the first page of GetQueryResultsResponse using the jobId*/
   @VisibleForTesting
   GetQueryResultsResponse getQueryResultsFirstPage(JobId jobId) {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionProperty.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionProperty.java
@@ -55,7 +55,8 @@ public final class ConnectionProperty {
     private String key;
     private String value;
 
-    private Builder() {};
+    private Builder() {}
+    ;
 
     private Builder(ConnectionProperty properties) {
       this.key = properties.key;

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ExternalTableDefinition.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ExternalTableDefinition.java
@@ -167,7 +167,8 @@ public abstract class ExternalTableDefinition extends TableDefinition {
     /** Sets the table Hive partitioning options. */
     public Builder setHivePartitioningOptions(HivePartitioningOptions hivePartitioningOptions) {
       return setHivePartitioningOptionsInner(hivePartitioningOptions);
-    };
+    }
+    ;
 
     /**
      * When creating an external table, the user can provide a reference file with the table schema.
@@ -253,7 +254,8 @@ public abstract class ExternalTableDefinition extends TableDefinition {
   @Nullable
   public Boolean ignoreUnknownValues() {
     return getIgnoreUnknownValues();
-  };
+  }
+  ;
 
   @Nullable
   public abstract Boolean getIgnoreUnknownValues();

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobException.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobException.java
@@ -34,6 +34,7 @@ public class JobException extends RuntimeException {
   public JobId getId() {
     return id;
   }
+
   /**
    * The errors reported by the job.
    *

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobStatistics.java
@@ -1400,7 +1400,8 @@ public abstract class JobStatistics implements Serializable {
       private String name;
       private Long slotMs;
 
-      private Builder() {};
+      private Builder() {}
+      ;
 
       Builder setName(String name) {
         this.name = name;
@@ -1486,7 +1487,8 @@ public abstract class JobStatistics implements Serializable {
 
       private String transactionId;
 
-      private Builder() {};
+      private Builder() {}
+      ;
 
       Builder setTransactionId(String transactionId) {
         this.transactionId = transactionId;
@@ -1557,7 +1559,8 @@ public abstract class JobStatistics implements Serializable {
 
       private String sessionId;
 
-      private Builder() {};
+      private Builder() {}
+      ;
 
       Builder setSessionId(String sessionId) {
         this.sessionId = sessionId;

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LegacySQLTypeName.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/LegacySQLTypeName.java
@@ -46,56 +46,70 @@ public final class LegacySQLTypeName extends StringEnumValue {
   /** Variable-length binary data. */
   public static final LegacySQLTypeName BYTES =
       type.createAndRegister("BYTES").setStandardType(StandardSQLTypeName.BYTES);
+
   /** Variable-length character (Unicode) data. */
   public static final LegacySQLTypeName STRING =
       type.createAndRegister("STRING").setStandardType(StandardSQLTypeName.STRING);
+
   /** A 64-bit signed integer value. */
   public static final LegacySQLTypeName INTEGER =
       type.createAndRegister("INTEGER").setStandardType(StandardSQLTypeName.INT64);
+
   /** A 64-bit IEEE binary floating-point value. */
   public static final LegacySQLTypeName FLOAT =
       type.createAndRegister("FLOAT").setStandardType(StandardSQLTypeName.FLOAT64);
+
   /**
    * A decimal value with 38 digits of precision and 9 digits of scale. Note, support for this type
    * is limited in legacy SQL.
    */
   public static final LegacySQLTypeName NUMERIC =
       type.createAndRegister("NUMERIC").setStandardType(StandardSQLTypeName.NUMERIC);
+
   /**
    * A decimal value with 76+ digits of precision (the 77th digit is partial) and 38 digits of scale
    */
   public static final LegacySQLTypeName BIGNUMERIC =
       type.createAndRegister("BIGNUMERIC").setStandardType(StandardSQLTypeName.BIGNUMERIC);
+
   /** A Boolean value (true or false). */
   public static final LegacySQLTypeName BOOLEAN =
       type.createAndRegister("BOOLEAN").setStandardType(StandardSQLTypeName.BOOL);
+
   /** Represents an absolute point in time, with microsecond precision. */
   public static final LegacySQLTypeName TIMESTAMP =
       type.createAndRegister("TIMESTAMP").setStandardType(StandardSQLTypeName.TIMESTAMP);
+
   /** Represents a logical calendar date. Note, support for this type is limited in legacy SQL. */
   public static final LegacySQLTypeName DATE =
       type.createAndRegister("DATE").setStandardType(StandardSQLTypeName.DATE);
+
   /** Represents a set of geographic points, represented as a Well Known Text (WKT) string. */
   public static final LegacySQLTypeName GEOGRAPHY =
       type.createAndRegister("GEOGRAPHY").setStandardType(StandardSQLTypeName.GEOGRAPHY);
+
   /**
    * Represents a time, independent of a specific date, to microsecond precision. Note, support for
    * this type is limited in legacy SQL.
    */
   public static final LegacySQLTypeName TIME =
       type.createAndRegister("TIME").setStandardType(StandardSQLTypeName.TIME);
+
   /**
    * Represents a year, month, day, hour, minute, second, and subsecond (microsecond precision).
    * Note, support for this type is limited in legacy SQL.
    */
   public static final LegacySQLTypeName DATETIME =
       type.createAndRegister("DATETIME").setStandardType(StandardSQLTypeName.DATETIME);
+
   /** A record type with a nested schema. */
   public static final LegacySQLTypeName RECORD =
       type.createAndRegister("RECORD").setStandardType(StandardSQLTypeName.STRUCT);
+
   /** Represents JSON data */
   public static final LegacySQLTypeName JSON =
       type.createAndRegister("JSON").setStandardType(StandardSQLTypeName.JSON);
+
   /** Represents duration or amount of time. */
   public static final LegacySQLTypeName INTERVAL =
       type.createAndRegister("INTERVAL").setStandardType(StandardSQLTypeName.INTERVAL);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ParquetOptions.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ParquetOptions.java
@@ -79,6 +79,7 @@ public class ParquetOptions extends FormatOptions {
       return new ParquetOptions(this);
     }
   }
+
   /** Returns a builder for the {@link ParquetOptions} object. */
   public Builder toBuilder() {
     return new Builder(this);

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/RoutineInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/RoutineInfo.java
@@ -429,7 +429,8 @@ public class RoutineInfo implements Serializable {
   /** Returns the Remote function specific options. */
   public RemoteFunctionOptions getRemoteFunctionOptions() {
     return remoteFunctionOptions;
-  };
+  }
+  ;
 
   /** Returns the data governance type of the routine, e.g. DATA_MASKING. */
   public String getDataGovernanceType() {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
@@ -234,6 +234,7 @@ public interface BigQueryRpc extends ServiceRpc {
 
   Tuple<String, Iterable<Routine>> listRoutines(
       String projectId, String datasetId, Map<Option, ?> options);
+
   /**
    * Deletes the requested routine.
    *

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelper.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelper.java
@@ -95,8 +95,7 @@ public class RemoteBigQueryHelper {
     try {
       HttpTransportOptions transportOptions = BigQueryOptions.getDefaultHttpTransportOptions();
       transportOptions =
-          transportOptions
-              .toBuilder()
+          transportOptions.toBuilder()
               .setConnectTimeout(connectTimeout)
               .setReadTimeout(connectTimeout)
               .build();
@@ -123,8 +122,7 @@ public class RemoteBigQueryHelper {
   public static RemoteBigQueryHelper create() {
     HttpTransportOptions transportOptions = BigQueryOptions.getDefaultHttpTransportOptions();
     transportOptions =
-        transportOptions
-            .toBuilder()
+        transportOptions.toBuilder()
             .setConnectTimeout(connectTimeout)
             .setReadTimeout(connectTimeout)
             .build();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -795,9 +795,7 @@ public class BigQueryImplTest {
   @Test
   public void testUpdateDataset() throws IOException {
     DatasetInfo updatedDatasetInfo =
-        DATASET_INFO
-            .setProjectId(OTHER_PROJECT)
-            .toBuilder()
+        DATASET_INFO.setProjectId(OTHER_PROJECT).toBuilder()
             .setDescription("newDescription")
             .build();
     when(bigqueryRpcMock.patchSkipExceptionTranslation(
@@ -1256,9 +1254,7 @@ public class BigQueryImplTest {
   @Test
   public void testUpdateModel() throws IOException {
     ModelInfo updateModelInfo =
-        MODEL_INFO_WITH_PROJECT
-            .setProjectId(OTHER_PROJECT)
-            .toBuilder()
+        MODEL_INFO_WITH_PROJECT.setProjectId(OTHER_PROJECT).toBuilder()
             .setDescription("newDescription")
             .build();
     when(bigqueryRpcMock.patchSkipExceptionTranslation(updateModelInfo.toPb(), EMPTY_RPC_OPTIONS))
@@ -1402,8 +1398,7 @@ public class BigQueryImplTest {
         .thenThrow(new BigQueryException(500, "InternalError"))
         .thenReturn(responsePb);
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -1447,8 +1442,7 @@ public class BigQueryImplTest {
     when(bigqueryRpcMock.insertAll(PROJECT, DATASET, TABLE, requestPb))
         .thenThrow(new BigQueryException(500, "InternalError"));
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -1699,8 +1693,7 @@ public class BigQueryImplTest {
 
     bigquery = options.getService();
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -1725,8 +1718,7 @@ public class BigQueryImplTest {
 
     bigquery = options.getService();
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -1758,8 +1750,7 @@ public class BigQueryImplTest {
 
     bigquery = options.getService();
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -1789,8 +1780,7 @@ public class BigQueryImplTest {
 
     bigquery = options.getService();
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -1822,8 +1812,7 @@ public class BigQueryImplTest {
 
     bigquery = options.getService();
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -1852,8 +1841,7 @@ public class BigQueryImplTest {
 
     bigquery = options.getService();
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2654,8 +2642,7 @@ public class BigQueryImplTest {
         .thenReturn(responsePb);
 
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2730,8 +2717,7 @@ public class BigQueryImplTest {
         .thenThrow(new BigQueryException(500, "InternalError"))
         .thenReturn(DATASET_INFO_WITH_PROJECT.toPb());
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2748,8 +2734,7 @@ public class BigQueryImplTest {
     when(bigqueryRpcMock.getDatasetSkipExceptionTranslation(PROJECT, DATASET, EMPTY_RPC_OPTIONS))
         .thenThrow(new BigQueryException(501, exceptionMessage));
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2768,8 +2753,7 @@ public class BigQueryImplTest {
     when(bigqueryRpcMock.getDatasetSkipExceptionTranslation(PROJECT, DATASET, EMPTY_RPC_OPTIONS))
         .thenThrow(new RuntimeException(exceptionMessage));
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2786,8 +2770,7 @@ public class BigQueryImplTest {
   public void testQueryDryRun() throws Exception {
     // https://github.com/googleapis/google-cloud-java/issues/2479
     try {
-      options
-          .toBuilder()
+      options.toBuilder()
           .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
           .build()
           .getService()
@@ -2818,8 +2801,7 @@ public class BigQueryImplTest {
         .thenReturn(responsePb);
 
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2860,8 +2842,7 @@ public class BigQueryImplTest {
         .thenReturn(responsePb);
 
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2905,8 +2886,7 @@ public class BigQueryImplTest {
         .thenReturn(responsePb);
 
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -2974,8 +2954,7 @@ public class BigQueryImplTest {
         .thenReturn(responsePb);
 
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();
@@ -3092,9 +3071,7 @@ public class BigQueryImplTest {
   @Test
   public void testUpdateRoutine() throws IOException {
     RoutineInfo updatedRoutineInfo =
-        ROUTINE_INFO
-            .setProjectId(OTHER_PROJECT)
-            .toBuilder()
+        ROUTINE_INFO.setProjectId(OTHER_PROJECT).toBuilder()
             .setDescription("newDescription")
             .build();
     when(bigqueryRpcMock.updateSkipExceptionTranslation(

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ColumnReferenceTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ColumnReferenceTest.java
@@ -32,8 +32,7 @@ public class ColumnReferenceTest {
   public void testToBuilder() {
     compareColumnReferenceDefinition(COLUMN_REFERENCE, COLUMN_REFERENCE.toBuilder().build());
     ColumnReference columnReference =
-        COLUMN_REFERENCE
-            .toBuilder()
+        COLUMN_REFERENCE.toBuilder()
             .setReferencingColumn("col1")
             .setReferencedColumn("col2")
             .build();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ConnectionImplTest.java
@@ -155,8 +155,7 @@ public class ConnectionImplTest {
             .setNumBufferedRows(DEFAULT_PAGE_SIZE)
             .build();
     bigquery =
-        options
-            .toBuilder()
+        options.toBuilder()
             .setRetrySettings(ServiceOptions.getDefaultRetrySettings())
             .build()
             .getService();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/CopyJobConfigurationTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/CopyJobConfigurationTest.java
@@ -67,8 +67,7 @@ public class CopyJobConfigurationTest {
         COPY_JOB_CONFIGURATION_MULTIPLE_TABLES,
         COPY_JOB_CONFIGURATION_MULTIPLE_TABLES.toBuilder().build());
     CopyJobConfiguration jobConfiguration =
-        COPY_JOB_CONFIGURATION
-            .toBuilder()
+        COPY_JOB_CONFIGURATION.toBuilder()
             .setDestinationTable(TableId.of("dataset", "newTable"))
             .build();
     assertEquals("newTable", jobConfiguration.getDestinationTable().getTable());
@@ -143,8 +142,7 @@ public class CopyJobConfigurationTest {
   @Test
   public void testSetProjectIdDoNotOverride() {
     CopyJobConfiguration configuration =
-        COPY_JOB_CONFIGURATION_MULTIPLE_TABLES
-            .toBuilder()
+        COPY_JOB_CONFIGURATION_MULTIPLE_TABLES.toBuilder()
             .setSourceTables(
                 Lists.transform(
                     SOURCE_TABLES,

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetInfoTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/DatasetInfoTest.java
@@ -92,8 +92,7 @@ public class DatasetInfoTest {
           .setResourceTags(RESOURCE_TAGS)
           .build();
   private static final DatasetInfo DATASET_INFO_COMPLETE =
-      DATASET_INFO
-          .toBuilder()
+      DATASET_INFO.toBuilder()
           .setDatasetId(DATASET_ID_COMPLETE)
           .setAcl(ACCESS_RULES_COMPLETE)
           .build();
@@ -111,8 +110,7 @@ public class DatasetInfoTest {
         DATASET_INFO_COMPLETE_WITH_IAM_MEMBER,
         DATASET_INFO_COMPLETE_WITH_IAM_MEMBER.toBuilder().build());
     DatasetInfo datasetInfo =
-        DATASET_INFO
-            .toBuilder()
+        DATASET_INFO.toBuilder()
             .setDatasetId(DatasetId.of("dataset2"))
             .setDescription("description2")
             .build();
@@ -141,8 +139,7 @@ public class DatasetInfoTest {
             .setConnection("connection2")
             .build();
     DatasetInfo datasetInfo =
-        DATASET_INFO_COMPLETE_WITH_EXTERNAL_DATASET_REFERENCE
-            .toBuilder()
+        DATASET_INFO_COMPLETE_WITH_EXTERNAL_DATASET_REFERENCE.toBuilder()
             .setExternalDatasetReference(externalDatasetReference)
             .build();
     assertEquals(externalDatasetReference, datasetInfo.getExternalDatasetReference());

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ExternalTableDefinitionTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ExternalTableDefinitionTest.java
@@ -87,16 +87,14 @@ public class ExternalTableDefinitionTest {
     compareExternalTableDefinition(
         EXTERNAL_TABLE_DEFINITION, EXTERNAL_TABLE_DEFINITION.toBuilder().build());
     ExternalTableDefinition externalTableDefinition =
-        EXTERNAL_TABLE_DEFINITION
-            .toBuilder()
+        EXTERNAL_TABLE_DEFINITION.toBuilder()
             .setCompression("NONE")
             .setConnectionId("00000")
             .build();
     assertEquals("NONE", externalTableDefinition.getCompression());
     assertEquals("00000", externalTableDefinition.getConnectionId());
     externalTableDefinition =
-        externalTableDefinition
-            .toBuilder()
+        externalTableDefinition.toBuilder()
             .setCompression(COMPRESSION)
             .setConnectionId(CONNECTION_ID)
             .build();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ExtractJobConfigurationTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ExtractJobConfigurationTest.java
@@ -92,8 +92,7 @@ public class ExtractJobConfigurationTest {
     compareExtractJobConfiguration(
         EXTRACT_CONFIGURATION_MODEL, EXTRACT_CONFIGURATION_MODEL.toBuilder().build());
     ExtractJobConfiguration modelJob =
-        EXTRACT_CONFIGURATION_MODEL
-            .toBuilder()
+        EXTRACT_CONFIGURATION_MODEL.toBuilder()
             .setSourceModel(ModelId.of("dataset", "newModel"))
             .build();
     assertEquals("newModel", modelJob.getSourceModel().getModel());
@@ -102,8 +101,7 @@ public class ExtractJobConfigurationTest {
     compareExtractJobConfiguration(
         EXTRACT_CONFIGURATION_AVRO, EXTRACT_CONFIGURATION_AVRO.toBuilder().build());
     ExtractJobConfiguration avroJob =
-        EXTRACT_CONFIGURATION_AVRO
-            .toBuilder()
+        EXTRACT_CONFIGURATION_AVRO.toBuilder()
             .setSourceTable(TableId.of("dataset", "avroTable"))
             .build();
     assertEquals("avroTable", avroJob.getSourceTable().getTable());
@@ -223,15 +221,13 @@ public class ExtractJobConfigurationTest {
   @Test
   public void testSetProjectIdDoNotOverride() {
     ExtractJobConfiguration configuration =
-        EXTRACT_CONFIGURATION
-            .toBuilder()
+        EXTRACT_CONFIGURATION.toBuilder()
             .setSourceTable(TABLE_ID.setProjectId(TEST_PROJECT_ID))
             .build()
             .setProjectId("do-not-update");
     assertEquals(TEST_PROJECT_ID, configuration.getSourceTable().getProject());
     ExtractJobConfiguration modelConfiguration =
-        EXTRACT_CONFIGURATION_MODEL
-            .toBuilder()
+        EXTRACT_CONFIGURATION_MODEL.toBuilder()
             .setSourceModel(MODEL_ID.setProjectId(TEST_PROJECT_ID))
             .build()
             .setProjectId("do-not-update");

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ForeignKeyTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ForeignKeyTest.java
@@ -54,8 +54,7 @@ public class ForeignKeyTest {
             .setReferencedColumn("to2")
             .build());
     ForeignKey foreignKey =
-        FOREIGN_KEY
-            .toBuilder()
+        FOREIGN_KEY.toBuilder()
             .setName("test")
             .setReferencedTable(referencedTable)
             .setColumnReferences(columnReferences)

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/GoogleSheetsOptionsTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/GoogleSheetsOptionsTest.java
@@ -44,16 +44,14 @@ public class GoogleSheetsOptionsTest {
     compareGoogleSheetsOptions(
         GOOGLE_SHEETS_OPTIONS_RANGE, GOOGLE_SHEETS_OPTIONS_RANGE.toBuilder().build());
     GoogleSheetsOptions googleSheetsOptionsRange =
-        GOOGLE_SHEETS_OPTIONS_RANGE
-            .toBuilder()
+        GOOGLE_SHEETS_OPTIONS_RANGE.toBuilder()
             .setSkipLeadingRows(123)
             .setRange("sheet1!A1:A100")
             .build();
     assertThat(googleSheetsOptionsRange.getSkipLeadingRows()).isEqualTo(123);
     assertThat(googleSheetsOptionsRange.getRange()).isEqualTo("sheet1!A1:A100");
     googleSheetsOptionsRange =
-        googleSheetsOptionsRange
-            .toBuilder()
+        googleSheetsOptionsRange.toBuilder()
             .setSkipLeadingRows(SKIP_LEADING_ROWS)
             .setRange(RANGE)
             .build();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/LoadJobConfigurationTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/LoadJobConfigurationTest.java
@@ -151,8 +151,7 @@ public class LoadJobConfigurationTest {
   public void testToBuilder() {
     compareLoadJobConfiguration(LOAD_CONFIGURATION_CSV, LOAD_CONFIGURATION_CSV.toBuilder().build());
     LoadJobConfiguration configurationCSV =
-        LOAD_CONFIGURATION_CSV
-            .toBuilder()
+        LOAD_CONFIGURATION_CSV.toBuilder()
             .setDestinationTable(TableId.of("dataset", "newTable"))
             .build();
     assertEquals("newTable", configurationCSV.getDestinationTable().getTable());
@@ -162,8 +161,7 @@ public class LoadJobConfigurationTest {
     compareLoadJobConfiguration(
         LOAD_CONFIGURATION_BACKUP, LOAD_CONFIGURATION_BACKUP.toBuilder().build());
     LoadJobConfiguration configurationBackup =
-        LOAD_CONFIGURATION_BACKUP
-            .toBuilder()
+        LOAD_CONFIGURATION_BACKUP.toBuilder()
             .setDestinationTable(TableId.of("dataset", "newTable"))
             .build();
     assertEquals("newTable", configurationBackup.getDestinationTable().getTable());
@@ -173,8 +171,7 @@ public class LoadJobConfigurationTest {
     compareLoadJobConfiguration(
         LOAD_CONFIGURATION_AVRO, LOAD_CONFIGURATION_AVRO.toBuilder().build());
     LoadJobConfiguration configurationAvro =
-        LOAD_CONFIGURATION_AVRO
-            .toBuilder()
+        LOAD_CONFIGURATION_AVRO.toBuilder()
             .setDestinationTable(TableId.of("dataset", "newTable"))
             .build();
     assertEquals("newTable", configurationAvro.getDestinationTable().getTable());
@@ -225,8 +222,7 @@ public class LoadJobConfigurationTest {
   @Test
   public void testSetProjectIdDoNotOverride() {
     LoadConfiguration configuration =
-        LOAD_CONFIGURATION_CSV
-            .toBuilder()
+        LOAD_CONFIGURATION_CSV.toBuilder()
             .setDestinationTable(TABLE_ID.setProjectId(TEST_PROJECT_ID))
             .build()
             .setProjectId("do-not-update");

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ParquetOptionsTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/ParquetOptionsTest.java
@@ -36,8 +36,7 @@ public class ParquetOptionsTest {
     ParquetOptions parquetOptions = OPTIONS.toBuilder().setEnableListInference(true).build();
     assertEquals(true, parquetOptions.getEnableListInference());
     parquetOptions =
-        parquetOptions
-            .toBuilder()
+        parquetOptions.toBuilder()
             .setEnumAsString(true)
             .setMapTargetType("ARRAY_OF_STRUCT")
             .build();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
@@ -141,14 +141,12 @@ public class QueryJobConfigurationTest {
           .setParameterMode(PARAMETER_MODE)
           .build();
   private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION_ADD_POSITIONAL_PARAMETER =
-      QUERY_JOB_CONFIGURATION
-          .toBuilder()
+      QUERY_JOB_CONFIGURATION.toBuilder()
           .setPositionalParameters(ImmutableList.<QueryParameterValue>of())
           .addPositionalParameter(STRING_PARAMETER)
           .build();
   private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION_SET_NAME_PARAMETER =
-      QUERY_JOB_CONFIGURATION
-          .toBuilder()
+      QUERY_JOB_CONFIGURATION.toBuilder()
           .setPositionalParameters(ImmutableList.<QueryParameterValue>of())
           .setNamedParameters(NAME_PARAMETER)
           .build();
@@ -206,8 +204,7 @@ public class QueryJobConfigurationTest {
   @Test
   public void testSetProjectIdDoNotOverride() {
     QueryJobConfiguration configuration =
-        QUERY_JOB_CONFIGURATION
-            .toBuilder()
+        QUERY_JOB_CONFIGURATION.toBuilder()
             .setDestinationTable(TABLE_ID.setProjectId(TEST_PROJECT_ID))
             .build()
             .setProjectId("update-only-on-dataset");

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/RoutineInfoTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/RoutineInfoTest.java
@@ -52,8 +52,7 @@ public class RoutineInfoTest {
   private static final String BODY = "body";
 
   private static final RoutineInfo ROUTINE_INFO =
-      RoutineInfo.of(ROUTINE_ID)
-          .toBuilder()
+      RoutineInfo.of(ROUTINE_ID).toBuilder()
           .setEtag(ETAG)
           .setRoutineType(ROUTINE_TYPE)
           .setCreationTime(CREATION_TIME)

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableConstraintsTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableConstraintsTest.java
@@ -81,8 +81,7 @@ public class TableConstraintsTest {
             .build();
 
     TableConstraints tableConstraints =
-        TABLE_CONSTRAINTS
-            .toBuilder()
+        TABLE_CONSTRAINTS.toBuilder()
             .setForeignKeys(Arrays.asList(foreignKey1, foreignKey2))
             .setPrimaryKey(primaryKey)
             .build();

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/WriteChannelConfigurationTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/WriteChannelConfigurationTest.java
@@ -124,8 +124,7 @@ public class WriteChannelConfigurationTest {
   public void testToBuilder() {
     compareLoadConfiguration(LOAD_CONFIGURATION_CSV, LOAD_CONFIGURATION_CSV.toBuilder().build());
     WriteChannelConfiguration configuration =
-        LOAD_CONFIGURATION_CSV
-            .toBuilder()
+        LOAD_CONFIGURATION_CSV.toBuilder()
             .setDestinationTable(TableId.of("dataset", "newTable"))
             .build();
     assertEquals("newTable", configuration.getDestinationTable().getTable());
@@ -134,8 +133,7 @@ public class WriteChannelConfigurationTest {
 
     compareLoadConfiguration(LOAD_CONFIGURATION_AVRO, LOAD_CONFIGURATION_AVRO.toBuilder().build());
     WriteChannelConfiguration configurationAvro =
-        LOAD_CONFIGURATION_AVRO
-            .toBuilder()
+        LOAD_CONFIGURATION_AVRO.toBuilder()
             .setDestinationTable(TableId.of("dataset", "newTable"))
             .build();
     assertEquals("newTable", configurationAvro.getDestinationTable().getTable());

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1284,8 +1284,7 @@ public class ITBigQueryTest {
     updateLabels.put("a", null);
     Dataset updatedDataset =
         bigquery.update(
-            dataset
-                .toBuilder()
+            dataset.toBuilder()
                 .setDescription("Updated Description")
                 .setLabels(updateLabels)
                 .setStorageBillingModel("LOGICAL")
@@ -1358,8 +1357,7 @@ public class ITBigQueryTest {
     DatasetOption datasetOption = DatasetOption.accessPolicyVersion(3);
     Dataset updatedDataset =
         bigquery.update(
-            dataset
-                .toBuilder()
+            dataset.toBuilder()
                 .setDescription("Updated Description")
                 .setLabels(null)
                 .setAcl(acls)
@@ -2040,8 +2038,7 @@ public class ITBigQueryTest {
       fieldList.add(stringFieldWithPolicy);
       Schema updatedSchemaWithPolicyTag = Schema.of(fieldList);
       Table updatedTable =
-          createdTableForUpdate
-              .toBuilder()
+          createdTableForUpdate.toBuilder()
               .setDefinition(StandardTableDefinition.of(updatedSchemaWithPolicyTag))
               .build();
       updatedTable.update();
@@ -2411,14 +2408,10 @@ public class ITBigQueryTest {
 
     Table updatedTable =
         bigquery.update(
-            createdTable
-                .toBuilder()
+            createdTable.toBuilder()
                 .setDefinition(
                     ((ExternalTableDefinition) createdTable.getDefinition())
-                        .toBuilder()
-                        .setSchema(null)
-                        .setAutodetect(true)
-                        .build())
+                        .toBuilder().setSchema(null).setAutodetect(true).build())
                 .build(),
             BigQuery.TableOption.autodetectSchema(true));
     // Schema should change.
@@ -2518,8 +2511,7 @@ public class ITBigQueryTest {
     // get and modify policy
     Policy policy = bigquery.getIamPolicy(tableId);
     Policy editedPolicy =
-        policy
-            .toBuilder()
+        policy.toBuilder()
             .addIdentity(Role.of("roles/bigquery.dataViewer"), Identity.allUsers())
             .build();
     Policy updatedPolicy = bigquery.setIamPolicy(tableId, editedPolicy);
@@ -2655,8 +2647,7 @@ public class ITBigQueryTest {
     updateLabels.put("a", null);
     Table updatedTable =
         bigquery.update(
-            createdTable
-                .toBuilder()
+            createdTable.toBuilder()
                 .setDescription("Updated Description")
                 .setLabels(updateLabels)
                 .build());
@@ -2685,11 +2676,9 @@ public class ITBigQueryTest {
         .isNull();
 
     table =
-        table
-            .toBuilder()
+        table.toBuilder()
             .setDefinition(
-                tableDefinition
-                    .toBuilder()
+                tableDefinition.toBuilder()
                     .setTimePartitioning(TimePartitioning.of(Type.DAY, 42L))
                     .build())
             .build()
@@ -2700,11 +2689,9 @@ public class ITBigQueryTest {
         .isEqualTo(42L);
 
     table =
-        table
-            .toBuilder()
+        table.toBuilder()
             .setDefinition(
-                tableDefinition
-                    .toBuilder()
+                tableDefinition.toBuilder()
                     .setTimePartitioning(TimePartitioning.of(Type.DAY))
                     .build())
             .build()
@@ -3144,8 +3131,7 @@ public class ITBigQueryTest {
 
     // Mutate metadata.
     RoutineInfo newInfo =
-        routine
-            .toBuilder()
+        routine.toBuilder()
             .setBody("x * 4")
             .setReturnType(routine.getReturnType())
             .setArguments(routine.getArguments())
@@ -3578,9 +3564,7 @@ public class ITBigQueryTest {
     // Create a new bigQuery object but explicitly set the credentials.
     RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
     BigQueryOptions bigQueryOptions =
-        bigqueryHelper
-            .getOptions()
-            .toBuilder()
+        bigqueryHelper.getOptions().toBuilder()
             .setCredentials(bigquery.getOptions().getCredentials())
             .build();
     BigQuery bigQueryGoodCredentials = bigQueryOptions.getService();
@@ -3602,9 +3586,7 @@ public class ITBigQueryTest {
     // Scenario 2.
     // Create a new bigQuery object but explicitly an invalid credential.
     BigQueryOptions bigQueryOptionsBadCredentials =
-        bigqueryHelper
-            .getOptions()
-            .toBuilder()
+        bigqueryHelper.getOptions().toBuilder()
             .setCredentials(loadCredentials(FAKE_JSON_CRED_WITH_GOOGLE_DOMAIN))
             .build();
     BigQuery bigQueryBadCredentials = bigQueryOptionsBadCredentials.getService();
@@ -4090,7 +4072,8 @@ public class ITBigQueryTest {
 
   @Test
   public void testReadAPIIterationAndOrderAsync()
-      throws SQLException, ExecutionException,
+      throws SQLException,
+          ExecutionException,
           InterruptedException { // use read API to read 300K records and check the order
     String query =
         "SELECT date, county, state_name, confirmed_cases, deaths / 10 FROM "
@@ -4137,7 +4120,8 @@ public class ITBigQueryTest {
   // be uncompleted in 1000ms is nondeterministic! Though very likely it won't be complete in the
   // specified amount of time
   public void testExecuteSelectAsyncCancel()
-      throws SQLException, ExecutionException,
+      throws SQLException,
+          ExecutionException,
           InterruptedException { // use read API to read 300K records and check the order
     String query =
         "SELECT date, county, state_name, confirmed_cases, deaths FROM "
@@ -4183,7 +4167,8 @@ public class ITBigQueryTest {
   // be uncompleted in 1000ms is nondeterministic! Though very likely it won't be complete in the
   // specified amount of time
   public void testExecuteSelectAsyncTimeout()
-      throws SQLException, ExecutionException,
+      throws SQLException,
+          ExecutionException,
           InterruptedException { // use read API to read 300K records and check the order
     String query =
         "SELECT date, county, state_name, confirmed_cases, deaths FROM "
@@ -7219,9 +7204,7 @@ public class ITBigQueryTest {
   public void testUniverseDomainWithInvalidUniverseDomain() {
     RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
     BigQueryOptions bigQueryOptions =
-        bigqueryHelper
-            .getOptions()
-            .toBuilder()
+        bigqueryHelper.getOptions().toBuilder()
             .setCredentials(loadCredentials(FAKE_JSON_CRED_WITH_GOOGLE_DOMAIN))
             .setUniverseDomain("invalid.domain")
             .build();
@@ -7245,9 +7228,7 @@ public class ITBigQueryTest {
   public void testInvalidUniverseDomainWithMismatchCredentials() {
     RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
     BigQueryOptions bigQueryOptions =
-        bigqueryHelper
-            .getOptions()
-            .toBuilder()
+        bigqueryHelper.getOptions().toBuilder()
             .setCredentials(loadCredentials(FAKE_JSON_CRED_WITH_INVALID_DOMAIN))
             .build();
     BigQuery bigQuery = bigQueryOptions.getService();


### PR DESCRIPTION
https://github.com/googleapis/java-shared-config/pull/1003 was merged in java-shared-config and will bring the latest google-java-format formatter to this repository. 

This PR contains: 
 * Changes after running `mvn fmt:format` using this new version.
 * Update `.kokoro/build.sh` to use the `com.spotify.fmt` group ID (the fmt plugin changed group ID [since 2.14.0](https://github.com/spotify/fmt-maven-plugin/releases/tag/2.14.0)).
 * Update our CI pipeline to use Java 17 for the lint job ([required](https://github.com/google/google-java-format/releases/tag/v1.25.0) by the latest google-java-format).
   * Note: the CI pipeline is templated, but these changes are not being propagated (tracked in https://github.com/googleapis/sdk-platform-java/issues/3701), so a manual change is needed for the time being.