### PR TITLE
feat: add WRITE_TRUNCATE_DATA as an enum value for write disposition

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobInfo.java
@@ -66,6 +66,9 @@ public class JobInfo implements Serializable {
     /** Configures the job to overwrite the table data if table already exists. */
     WRITE_TRUNCATE,
 
+    /** Configures the job to retain schema and constraints on an existing table, and truncate and replace data. */
+    WRITE_TRUNCATE_DATA,
+
     /** Configures the job to append data to the table if it already exists. */
     WRITE_APPEND,
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobInfo.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/JobInfo.java
@@ -66,7 +66,10 @@ public class JobInfo implements Serializable {
     /** Configures the job to overwrite the table data if table already exists. */
     WRITE_TRUNCATE,
 
-    /** Configures the job to retain schema and constraints on an existing table, and truncate and replace data. */
+    /**
+     * Configures the job to retain schema and constraints on an existing table, and truncate and
+     * replace data.
+     */
     WRITE_TRUNCATE_DATA,
 
     /** Configures the job to append data to the table if it already exists. */


### PR DESCRIPTION
For existing tables, WRITE_TRUNCATE_DATA preserves schema/constraints and replaces data.

internal issue: b/406848221