### PR TITLE
docs(bigquery): Update TableResult.getTotalRows() docstring

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
@@ -61,6 +61,11 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
   @Nullable
   public abstract Schema getSchema();
 
+  /**
+   * Returns the total number of rows in the complete result set, which can be more than the number
+   * of rows in the first page of results. If no rows are returned, this value can still be greater
+   * than 0 if any rows were affected by the query, such as INSERT, UPDATE, or DELETE queries.
+   */
   public abstract long getTotalRows();
 
   public abstract Page<FieldValueList> getPageNoSchema();


### PR DESCRIPTION
After some investigation into [Issue #3776](https://github.com/googleapis/java-bigquery/issues/3776), we noticed that getTotalRows() would return 1 for queries that didn't actually return any rows. This docstring explains why the method can potentially return a non-zero value for queries that don't return any rows, such as INSERT, UPDATE, and DELETE.

The reason for this is that the totalRows value can be set to the [numDmlAffectedRows](https://github.com/googleapis/java-bigquery/blob/d6e52e9221a48a374e59e65e46ff230f1424d218/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java#L1470) in some cases.