### PR TITLE
feat(bigquery): Support Fine Grained ACLs for Datasets

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -77,6 +77,40 @@ public interface BigQuery extends Service<BigQueryOptions> {
     }
   }
 
+  enum DatasetView {
+    FULL("full"),
+    METADATA("metadata"),
+    ACL("acl");
+
+    private final String view;
+
+    DatasetView(String view) {
+      this.view = view;
+    }
+
+    @Override
+    public String toString() {
+      return view.toUpperCase();
+    }
+  }
+
+  enum DatasetUpdateMode {
+    UPDATE_FULL("update_full"),
+    UPDATE_METADATA("update_metadata"),
+    UPDATE_ACL("update_acl");
+
+    private final String updateMode;
+
+    DatasetUpdateMode(String updateMode) {
+      this.updateMode = updateMode;
+    }
+
+    @Override
+    public String toString() {
+      return updateMode.toUpperCase();
+    }
+  }
+
   /**
    * Fields of a BigQuery Table resource.
    *
@@ -306,6 +340,22 @@ public interface BigQuery extends Service<BigQueryOptions> {
      */
     public static DatasetOption accessPolicyVersion(Integer accessPolicyVersion) {
       return new DatasetOption(BigQueryRpc.Option.ACCESS_POLICY_VERSION, accessPolicyVersion);
+    }
+
+    /**
+     * Returns an option to specify the view that determines which dataset information is returned.
+     * By default, metadata and ACL information are returned.
+     */
+    public static DatasetOption datasetView(DatasetView datasetView) {
+      return new DatasetOption(BigQueryRpc.Option.DATASET_VIEW, datasetView);
+    }
+
+    /**
+     * Returns an option to specify the fields of dataset that update/patch operation is targeting.
+     * By default, both metadata and ACL fields are updated.
+     */
+    public static DatasetOption updateMode(DatasetUpdateMode updateMode) {
+      return new DatasetOption(BigQueryRpc.Option.DATASET_UPDATE_MODE, updateMode);
     }
   }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -78,6 +78,7 @@ public interface BigQuery extends Service<BigQueryOptions> {
   }
 
   enum DatasetView {
+    DATASET_VIEW_UNSPECIFIED("DATASET_VIEW_UNSPECIFIED"),
     FULL("FULL"),
     METADATA("METADATA"),
     ACL("ACL");
@@ -95,6 +96,7 @@ public interface BigQuery extends Service<BigQueryOptions> {
   }
 
   enum DatasetUpdateMode {
+    UPDATE_MODE_UNSPECIFIED("UPDATE_MODE_UNSPECIFIED"),
     UPDATE_FULL("UPDATE_FULL"),
     UPDATE_METADATA("UPDATE_METADATA"),
     UPDATE_ACL("UPDATE_ACL");

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQuery.java
@@ -78,9 +78,9 @@ public interface BigQuery extends Service<BigQueryOptions> {
   }
 
   enum DatasetView {
-    FULL("full"),
-    METADATA("metadata"),
-    ACL("acl");
+    FULL("FULL"),
+    METADATA("METADATA"),
+    ACL("ACL");
 
     private final String view;
 
@@ -90,14 +90,14 @@ public interface BigQuery extends Service<BigQueryOptions> {
 
     @Override
     public String toString() {
-      return view.toUpperCase();
+      return view;
     }
   }
 
   enum DatasetUpdateMode {
-    UPDATE_FULL("update_full"),
-    UPDATE_METADATA("update_metadata"),
-    UPDATE_ACL("update_acl");
+    UPDATE_FULL("UPDATE_FULL"),
+    UPDATE_METADATA("UPDATE_METADATA"),
+    UPDATE_ACL("UPDATE_ACL");
 
     private final String updateMode;
 
@@ -107,7 +107,7 @@ public interface BigQuery extends Service<BigQueryOptions> {
 
     @Override
     public String toString() {
-      return updateMode.toUpperCase();
+      return updateMode;
     }
   }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/BigQueryRpc.java
@@ -60,7 +60,9 @@ public interface BigQueryRpc extends ServiceRpc {
     TABLE_METADATA_VIEW("view"),
     RETRY_OPTIONS("retryOptions"),
     BIGQUERY_RETRY_CONFIG("bigQueryRetryConfig"),
-    ACCESS_POLICY_VERSION("accessPolicyVersion");
+    ACCESS_POLICY_VERSION("accessPolicyVersion"),
+    DATASET_VIEW("datasetView"),
+    DATASET_UPDATE_MODE("datasetUpdateMode");
 
     private final String value;
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/spi/v2/HttpBigQueryRpc.java
@@ -149,10 +149,11 @@ public class HttpBigQueryRpc implements BigQueryRpc {
             .get(projectId, datasetId)
             .setFields(Option.FIELDS.getString(options))
             .setPrettyPrint(false);
-    for (Map.Entry<Option, ?> entry : options.entrySet()) {
-      if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
-        bqGetRequest.setAccessPolicyVersion((Integer) entry.getValue());
-      }
+    if (options.containsKey(Option.ACCESS_POLICY_VERSION)) {
+      bqGetRequest.setAccessPolicyVersion((Integer) options.get(Option.ACCESS_POLICY_VERSION));
+    }
+    if (options.containsKey(Option.DATASET_VIEW)) {
+      bqGetRequest.setDatasetView(options.get(Option.DATASET_VIEW).toString());
     }
     return bqGetRequest.execute();
   }
@@ -350,10 +351,11 @@ public class HttpBigQueryRpc implements BigQueryRpc {
             .patch(reference.getProjectId(), reference.getDatasetId(), dataset)
             .setPrettyPrint(false)
             .setFields(Option.FIELDS.getString(options));
-    for (Map.Entry<Option, ?> entry : options.entrySet()) {
-      if (entry.getKey() == Option.ACCESS_POLICY_VERSION && entry.getValue() != null) {
-        bqPatchRequest.setAccessPolicyVersion((Integer) entry.getValue());
-      }
+    if (options.containsKey(Option.ACCESS_POLICY_VERSION)) {
+      bqPatchRequest.setAccessPolicyVersion((Integer) options.get(Option.ACCESS_POLICY_VERSION));
+    }
+    if (options.containsKey(Option.DATASET_UPDATE_MODE)) {
+      bqPatchRequest.setUpdateMode(options.get(Option.DATASET_UPDATE_MODE).toString());
     }
     return bqPatchRequest.execute();
   }

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -48,6 +48,8 @@ import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQuery.DatasetField;
 import com.google.cloud.bigquery.BigQuery.DatasetListOption;
 import com.google.cloud.bigquery.BigQuery.DatasetOption;
+import com.google.cloud.bigquery.BigQuery.DatasetUpdateMode;
+import com.google.cloud.bigquery.BigQuery.DatasetView;
 import com.google.cloud.bigquery.BigQuery.JobField;
 import com.google.cloud.bigquery.BigQuery.JobListOption;
 import com.google.cloud.bigquery.BigQuery.JobOption;
@@ -1235,7 +1237,8 @@ public class ITBigQueryTest {
             "requests after the year 2024",
             "location");
     Acl acl = Acl.of(user, role, condition);
-    DatasetOption datasetOption = DatasetOption.accessPolicyVersion(3);
+    DatasetOption accessPolicyOption = DatasetOption.accessPolicyVersion(3);
+    DatasetOption viewOption = DatasetOption.datasetView(DatasetView.FULL);
 
     Dataset dataset =
         bigquery.create(
@@ -1243,10 +1246,10 @@ public class ITBigQueryTest {
                 .setDescription("Some Description")
                 .setAcl(ImmutableList.of(acl))
                 .build(),
-            datasetOption);
+            accessPolicyOption);
     assertThat(dataset).isNotNull();
 
-    Dataset remoteDataset = bigquery.getDataset(accessPolicyDataset, datasetOption);
+    Dataset remoteDataset = bigquery.getDataset(accessPolicyDataset, accessPolicyOption, viewOption);
     assertNotNull(remoteDataset);
     assertEquals(dataset.getDescription(), remoteDataset.getDescription());
     assertNotNull(remoteDataset.getCreationTime());
@@ -1355,6 +1358,7 @@ public class ITBigQueryTest {
     acls.add(acl);
 
     DatasetOption datasetOption = DatasetOption.accessPolicyVersion(3);
+    DatasetOption updateModeOption = DatasetOption.updateMode(DatasetUpdateMode.UPDATE_FULL);
     Dataset updatedDataset =
         bigquery.update(
             dataset.toBuilder()
@@ -1362,7 +1366,7 @@ public class ITBigQueryTest {
                 .setLabels(null)
                 .setAcl(acls)
                 .build(),
-            datasetOption);
+            datasetOption, updateModeOption);
     assertNotNull(updatedDataset);
     assertEquals(updatedDataset.getDescription(), "Updated Description");
     assertThat(updatedDataset.getLabels().isEmpty());

--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -1249,7 +1249,8 @@ public class ITBigQueryTest {
             accessPolicyOption);
     assertThat(dataset).isNotNull();
 
-    Dataset remoteDataset = bigquery.getDataset(accessPolicyDataset, accessPolicyOption, viewOption);
+    Dataset remoteDataset =
+        bigquery.getDataset(accessPolicyDataset, accessPolicyOption, viewOption);
     assertNotNull(remoteDataset);
     assertEquals(dataset.getDescription(), remoteDataset.getDescription());
     assertNotNull(remoteDataset.getCreationTime());
@@ -1366,7 +1367,8 @@ public class ITBigQueryTest {
                 .setLabels(null)
                 .setAcl(acls)
                 .build(),
-            datasetOption, updateModeOption);
+            datasetOption,
+            updateModeOption);
     assertNotNull(updatedDataset);
     assertEquals(updatedDataset.getDescription(), "Updated Description");
     assertThat(updatedDataset.getLabels().isEmpty());


### PR DESCRIPTION
This PR adds the options dataset_view and update_mode to the get and patch dataset requests respectively. These new options decide whether the metadata and or ACL information should be checked when retrieving or updating a dataset. 