### PR TITLE
deps: rollback netty.version to v4.1.119.Final

### DIFF
--- a/google-cloud-bigquery/pom.xml
+++ b/google-cloud-bigquery/pom.xml
@@ -15,7 +15,7 @@
   </parent>
   <properties>
     <site.installationModule>google-cloud-bigquery</site.installationModule>
-    <netty.version>4.2.1.Final</netty.version>
+    <netty.version>4.1.119.Final</netty.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
The reason for the rollback is that io-netty version v4.2.1.Final had conflicts with the dep apache.arrow