### PR TITLE
feat(bigquery): Integrate Otel into retries, jobs, and more

### DIFF
--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -4,6 +4,12 @@
   <!-- TODO: REMOVE AFTER RELEASE -->
   <difference>
     <differenceType>7004</differenceType>
+    <className>com/google/cloud/bigquery/BigQueryRetryHelper</className>
+    <method>com.google.cloud.bigquery.V runWithRetries(java.util.concurrent.Callable, com.google.api.gax.retrying.RetrySettings, com.google.api.gax.retrying.ResultRetryAlgorithm, com.google.api.core.ApiClock, com.google.cloud.bigquery.BigQueryRetryConfig, boolean, io.opentelemetry.api.trace.Tracer)</method>
+    <justification>A Tracer object is needed to use Otel and runWithRetries is only called in a few files, so it should be fine to update the signature</justification>
+  </difference>
+  <difference>
+    <differenceType>7004</differenceType>
     <className>com/google/cloud/bigquery/spi/v2/BigQueryRpc</className>
     <method>com.google.api.services.bigquery.model.GetQueryResultsResponse getQueryResultsWithRowLimit(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer)</method>
     <justification>getQueryResultsWithRowLimit is just used by ConnectionImpl at the moment so it should be fine to update the signature instead of writing an overloaded method</justification>

--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -5,7 +5,7 @@
   <difference>
     <differenceType>7004</differenceType>
     <className>com/google/cloud/bigquery/BigQueryRetryHelper</className>
-    <method>com.google.cloud.bigquery.V runWithRetries(java.util.concurrent.Callable, com.google.api.gax.retrying.RetrySettings, com.google.api.gax.retrying.ResultRetryAlgorithm, com.google.api.core.ApiClock, com.google.cloud.bigquery.BigQueryRetryConfig)</method>
+    <method>java.lang.Object runWithRetries(java.util.concurrent.Callable, com.google.api.gax.retrying.RetrySettings, com.google.api.gax.retrying.ResultRetryAlgorithm, com.google.api.core.ApiClock, com.google.cloud.bigquery.BigQueryRetryConfig)</method>
     <justification>A Tracer object is needed to use Otel and runWithRetries is only called in a few files, so it should be fine to update the signature</justification>
   </difference>
   <difference>

--- a/google-cloud-bigquery/clirr-ignored-differences.xml
+++ b/google-cloud-bigquery/clirr-ignored-differences.xml
@@ -5,7 +5,7 @@
   <difference>
     <differenceType>7004</differenceType>
     <className>com/google/cloud/bigquery/BigQueryRetryHelper</className>
-    <method>com.google.cloud.bigquery.V runWithRetries(java.util.concurrent.Callable, com.google.api.gax.retrying.RetrySettings, com.google.api.gax.retrying.ResultRetryAlgorithm, com.google.api.core.ApiClock, com.google.cloud.bigquery.BigQueryRetryConfig, boolean, io.opentelemetry.api.trace.Tracer)</method>
+    <method>com.google.cloud.bigquery.V runWithRetries(java.util.concurrent.Callable, com.google.api.gax.retrying.RetrySettings, com.google.api.gax.retrying.ResultRetryAlgorithm, com.google.api.core.ApiClock, com.google.cloud.bigquery.BigQueryRetryConfig)</method>
     <justification>A Tracer object is needed to use Otel and runWithRetries is only called in a few files, so it should be fine to update the signature</justification>
   </difference>
   <difference>

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -295,7 +295,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -340,7 +342,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -394,7 +398,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -488,7 +494,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                   getOptions().getClock(),
                   getBigQueryRetryConfig(optionsMap) != null
                       ? getBigQueryRetryConfig(optionsMap)
-                      : DEFAULT_RETRY_CONFIG));
+                      : DEFAULT_RETRY_CONFIG,
+                  getOptions().isOpenTelemetryTracingEnabled(),
+                  getOptions().getOpenTelemetryTracer()));
         } catch (BigQueryRetryHelperException e) {
           throw BigQueryException.translateAndThrow(e);
         }
@@ -580,7 +588,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer());
       return Dataset.fromPb(this, answer);
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
@@ -644,7 +654,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               serviceOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              serviceOptions.isOpenTelemetryTracingEnabled(),
+              serviceOptions.getOpenTelemetryTracer());
       String cursor = result.x();
       return new PageImpl<>(
           new DatasetPageFetcher(projectId, serviceOptions, cursor, optionsMap),
@@ -694,7 +706,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           getOptions().getRetrySettings(),
           BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
           getOptions().getClock(),
-          EMPTY_RETRY_CONFIG);
+          EMPTY_RETRY_CONFIG,
+          getOptions().isOpenTelemetryTracingEnabled(),
+          getOptions().getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
         return false;
@@ -743,7 +757,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           getOptions().getRetrySettings(),
           BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
           getOptions().getClock(),
-          EMPTY_RETRY_CONFIG);
+          EMPTY_RETRY_CONFIG,
+          getOptions().isOpenTelemetryTracingEnabled(),
+          getOptions().getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
         return false;
@@ -787,7 +803,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           getOptions().getRetrySettings(),
           BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
           getOptions().getClock(),
-          EMPTY_RETRY_CONFIG);
+          EMPTY_RETRY_CONFIG,
+          getOptions().isOpenTelemetryTracingEnabled(),
+          getOptions().getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
         return false;
@@ -831,7 +849,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           getOptions().getRetrySettings(),
           BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
           getOptions().getClock(),
-          EMPTY_RETRY_CONFIG);
+          EMPTY_RETRY_CONFIG,
+          getOptions().isOpenTelemetryTracingEnabled(),
+          getOptions().getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
         return false;
@@ -873,7 +893,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           getOptions().getRetrySettings(),
           BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
           getOptions().getClock(),
-          EMPTY_RETRY_CONFIG);
+          EMPTY_RETRY_CONFIG,
+          getOptions().isOpenTelemetryTracingEnabled(),
+          getOptions().getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -912,7 +934,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -957,7 +981,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -1001,7 +1027,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -1045,7 +1073,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -1097,7 +1127,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer());
       return Table.fromPb(this, answer);
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
@@ -1154,7 +1186,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer());
       return Model.fromPb(this, answer);
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
@@ -1211,7 +1245,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer());
       return Routine.fromPb(this, answer);
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
@@ -1427,7 +1463,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               serviceOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              serviceOptions.isOpenTelemetryTracingEnabled(),
+              serviceOptions.getOpenTelemetryTracer());
       String cursor = result.x();
       Iterable<Table> tables =
           Iterables.transform(
@@ -1466,7 +1504,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               serviceOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              serviceOptions.isOpenTelemetryTracingEnabled(),
+              serviceOptions.getOpenTelemetryTracer());
       String cursor = result.x();
       Iterable<Model> models =
           Iterables.transform(
@@ -1505,7 +1545,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               serviceOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              serviceOptions.isOpenTelemetryTracingEnabled(),
+              serviceOptions.getOpenTelemetryTracer());
       String cursor = result.x();
       Iterable<Routine> routines =
           Iterables.transform(
@@ -1585,7 +1627,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
                   getOptions().getRetrySettings(),
                   BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
                   getOptions().getClock(),
-                  EMPTY_RETRY_CONFIG);
+                  EMPTY_RETRY_CONFIG,
+                  getOptions().isOpenTelemetryTracingEnabled(),
+                  getOptions().getOpenTelemetryTracer());
         } catch (BigQueryRetryHelperException e) {
           throw BigQueryException.translateAndThrow(e);
         }
@@ -1677,7 +1721,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               serviceOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              serviceOptions.isOpenTelemetryTracingEnabled(),
+              serviceOptions.getOpenTelemetryTracer());
       String cursor = result.getPageToken();
       Map<BigQueryRpc.Option, ?> pageOptionMap =
           Strings.isNullOrEmpty(cursor) ? optionsMap : optionMap(TableDataListOption.startIndex(0));
@@ -1749,7 +1795,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer());
       return Job.fromPb(this, answer);
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
@@ -1804,7 +1852,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               serviceOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              serviceOptions.isOpenTelemetryTracingEnabled(),
+              serviceOptions.getOpenTelemetryTracer());
       String cursor = result.x();
       Iterable<Job> jobs =
           Iterables.transform(
@@ -1857,7 +1907,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           getOptions().getRetrySettings(),
           BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
           getOptions().getClock(),
-          EMPTY_RETRY_CONFIG);
+          EMPTY_RETRY_CONFIG,
+          getOptions().isOpenTelemetryTracingEnabled(),
+          getOptions().getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       if (isRetryErrorCodeHttpNotFound(e)) {
         return false;
@@ -1942,7 +1994,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              DEFAULT_RETRY_CONFIG);
+              DEFAULT_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer());
     } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -2117,7 +2171,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               serviceOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               serviceOptions.getClock(),
-              DEFAULT_RETRY_CONFIG);
+              DEFAULT_RETRY_CONFIG,
+              serviceOptions.isOpenTelemetryTracingEnabled(),
+              serviceOptions.getOpenTelemetryTracer());
 
       TableSchema schemaPb = results.getSchema();
 
@@ -2186,7 +2242,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -2230,7 +2288,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG));
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer()));
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     } finally {
@@ -2276,7 +2336,9 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
               getOptions().getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               getOptions().getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              getOptions().isOpenTelemetryTracingEnabled(),
+              getOptions().getOpenTelemetryTracer());
       return response.getPermissions() == null
           ? ImmutableList.of()
           : ImmutableList.copyOf(response.getPermissions());

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryHelper.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryHelper.java
@@ -52,7 +52,6 @@ public class BigQueryRetryHelper extends RetryHelper {
       runWithRetries =
           openTelemetryTracer
               .spanBuilder("com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries")
-              .setAttribute("bq.retry.retry_settings", retrySettings.toString())
               .startSpan();
     }
     try (Scope runWithRetriesScope = runWithRetries != null ? runWithRetries.makeCurrent() : null) {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryHelper.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryHelper.java
@@ -53,8 +53,6 @@ public class BigQueryRetryHelper extends RetryHelper {
           openTelemetryTracer
               .spanBuilder("com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries")
               .setAttribute("bq.retry.retry_settings", retrySettings.toString())
-              .setAttribute("bq.retry.result_retry_algorithm", resultRetryAlgorithm.toString())
-              .setAttribute("bq.retry.bigquery_retry_config", bigQueryRetryConfig.toString())
               .startSpan();
     }
     try (Scope runWithRetriesScope = runWithRetries != null ? runWithRetries.makeCurrent() : null) {

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryHelper.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryHelper.java
@@ -25,6 +25,9 @@ import com.google.api.gax.retrying.RetryingExecutor;
 import com.google.api.gax.retrying.RetryingFuture;
 import com.google.api.gax.retrying.TimedRetryAlgorithm;
 import com.google.cloud.RetryHelper;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -40,9 +43,21 @@ public class BigQueryRetryHelper extends RetryHelper {
       RetrySettings retrySettings,
       ResultRetryAlgorithm<?> resultRetryAlgorithm,
       ApiClock clock,
-      BigQueryRetryConfig bigQueryRetryConfig)
+      BigQueryRetryConfig bigQueryRetryConfig,
+      boolean isOpenTelemetryEnabled,
+      Tracer openTelemetryTracer)
       throws RetryHelperException {
-    try {
+    Span runWithRetries = null;
+    if (isOpenTelemetryEnabled && openTelemetryTracer != null) {
+      runWithRetries =
+          openTelemetryTracer
+              .spanBuilder("com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries")
+              .setAttribute("bq.retry.retry_settings", retrySettings.toString())
+              .setAttribute("bq.retry.result_retry_algorithm", resultRetryAlgorithm.toString())
+              .setAttribute("bq.retry.bigquery_retry_config", bigQueryRetryConfig.toString())
+              .startSpan();
+    }
+    try (Scope runWithRetriesScope = runWithRetries != null ? runWithRetries.makeCurrent() : null) {
       // Suppressing should be ok as a workaraund. Current and only ResultRetryAlgorithm
       // implementation does not use response at all, so ignoring its type is ok.
       @SuppressWarnings("unchecked")
@@ -59,6 +74,10 @@ public class BigQueryRetryHelper extends RetryHelper {
         throw new BigQueryRetryHelperException(new BigQueryException((IOException) e.getCause()));
       }
       throw new BigQueryRetryHelperException(e.getCause());
+    } finally {
+      if (runWithRetries != null) {
+        runWithRetries.end();
+      }
     }
   }
 

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -476,7 +476,9 @@ class ConnectionImpl implements Connection {
               bigQueryOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
-              retryConfig);
+              retryConfig,
+              bigQueryOptions.isOpenTelemetryTracingEnabled(),
+              bigQueryOptions.getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     }
@@ -932,7 +934,9 @@ class ConnectionImpl implements Connection {
               bigQueryOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              bigQueryOptions.isOpenTelemetryTracingEnabled(),
+              bigQueryOptions.getOpenTelemetryTracer());
     } catch (BigQueryRetryHelperException e) {
       if (e.getCause() instanceof BigQueryException) {
         if (((BigQueryException) e.getCause()).getCode() == HTTP_NOT_FOUND) {
@@ -977,7 +981,9 @@ class ConnectionImpl implements Connection {
               bigQueryOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
-              EMPTY_RETRY_CONFIG);
+              EMPTY_RETRY_CONFIG,
+              bigQueryOptions.isOpenTelemetryTracingEnabled(),
+              bigQueryOptions.getOpenTelemetryTracer());
 
       return results;
     } catch (BigQueryRetryHelperException e) {
@@ -1208,7 +1214,9 @@ class ConnectionImpl implements Connection {
                 bigQueryOptions.getRetrySettings(),
                 BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
                 bigQueryOptions.getClock(),
-                retryConfig);
+                retryConfig,
+                bigQueryOptions.isOpenTelemetryTracingEnabled(),
+                bigQueryOptions.getOpenTelemetryTracer());
 
         if (results.getErrors() != null) {
           List<BigQueryError> bigQueryErrors =
@@ -1471,7 +1479,9 @@ class ConnectionImpl implements Connection {
               bigQueryOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
-              retryConfig);
+              retryConfig,
+              bigQueryOptions.isOpenTelemetryTracingEnabled(),
+              bigQueryOptions.getOpenTelemetryTracer());
     } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
       logger.log(Level.WARNING, "\n Error occurred while calling createJobForQuery", e);
       throw BigQueryException.translateAndThrow(e);
@@ -1514,7 +1524,9 @@ class ConnectionImpl implements Connection {
               bigQueryOptions.getRetrySettings(),
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
-              retryConfig);
+              retryConfig,
+              bigQueryOptions.isOpenTelemetryTracingEnabled(),
+              bigQueryOptions.getOpenTelemetryTracer());
     } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -477,8 +477,8 @@ class ConnectionImpl implements Connection {
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
               retryConfig,
-              bigQueryOptions.isOpenTelemetryTracingEnabled(),
-              bigQueryOptions.getOpenTelemetryTracer());
+              false,
+              null);
     } catch (BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     }
@@ -935,8 +935,8 @@ class ConnectionImpl implements Connection {
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
               EMPTY_RETRY_CONFIG,
-              bigQueryOptions.isOpenTelemetryTracingEnabled(),
-              bigQueryOptions.getOpenTelemetryTracer());
+              false,
+              null);
     } catch (BigQueryRetryHelperException e) {
       if (e.getCause() instanceof BigQueryException) {
         if (((BigQueryException) e.getCause()).getCode() == HTTP_NOT_FOUND) {
@@ -982,8 +982,8 @@ class ConnectionImpl implements Connection {
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
               EMPTY_RETRY_CONFIG,
-              bigQueryOptions.isOpenTelemetryTracingEnabled(),
-              bigQueryOptions.getOpenTelemetryTracer());
+              false,
+              null);
 
       return results;
     } catch (BigQueryRetryHelperException e) {
@@ -1215,8 +1215,8 @@ class ConnectionImpl implements Connection {
                 BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
                 bigQueryOptions.getClock(),
                 retryConfig,
-                bigQueryOptions.isOpenTelemetryTracingEnabled(),
-                bigQueryOptions.getOpenTelemetryTracer());
+                false,
+                null);
 
         if (results.getErrors() != null) {
           List<BigQueryError> bigQueryErrors =
@@ -1480,8 +1480,8 @@ class ConnectionImpl implements Connection {
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
               retryConfig,
-              bigQueryOptions.isOpenTelemetryTracingEnabled(),
-              bigQueryOptions.getOpenTelemetryTracer());
+              false,
+              null);
     } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
       logger.log(Level.WARNING, "\n Error occurred while calling createJobForQuery", e);
       throw BigQueryException.translateAndThrow(e);
@@ -1525,8 +1525,8 @@ class ConnectionImpl implements Connection {
               BigQueryBaseService.BIGQUERY_EXCEPTION_HANDLER,
               bigQueryOptions.getClock(),
               retryConfig,
-              bigQueryOptions.isOpenTelemetryTracingEnabled(),
-              bigQueryOptions.getOpenTelemetryTracer());
+              false,
+              null);
     } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
     }

--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
@@ -29,6 +29,9 @@ import com.google.cloud.bigquery.BigQuery.QueryResultsOption;
 import com.google.cloud.bigquery.BigQuery.TableDataListOption;
 import com.google.cloud.bigquery.JobConfiguration.Type;
 import com.google.common.collect.ImmutableList;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.time.Duration;
@@ -172,7 +175,21 @@ public class Job extends JobInfo {
    */
   public boolean exists() {
     checkNotDryRun("exists");
-    return bigquery.getJob(getJobId(), JobOption.fields()) != null;
+    Span exists = null;
+    if (options.isOpenTelemetryTracingEnabled() && options.getOpenTelemetryTracer() != null) {
+      exists =
+          options
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.Job.exists")
+              .startSpan();
+    }
+    try (Scope existsScope = exists != null ? exists.makeCurrent() : null) {
+      return bigquery.getJob(getJobId(), JobOption.fields()) != null;
+    } finally {
+      if (exists != null) {
+        exists.end();
+      }
+    }
   }
 
   /**
@@ -193,8 +210,22 @@ public class Job extends JobInfo {
    */
   public boolean isDone() {
     checkNotDryRun("isDone");
-    Job job = bigquery.getJob(getJobId(), JobOption.fields(BigQuery.JobField.STATUS));
-    return job == null || JobStatus.State.DONE.equals(job.getStatus().getState());
+    Span isDone = null;
+    if (options.isOpenTelemetryTracingEnabled() && options.getOpenTelemetryTracer() != null) {
+      isDone =
+          options
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.Job.isDone")
+              .startSpan();
+    }
+    try (Scope isDoneScope = isDone != null ? isDone.makeCurrent() : null) {
+      Job job = bigquery.getJob(getJobId(), JobOption.fields(BigQuery.JobField.STATUS));
+      return job == null || JobStatus.State.DONE.equals(job.getStatus().getState());
+    } finally {
+      if (isDone != null) {
+        isDone.end();
+      }
+    }
   }
 
   /** See {@link #waitFor(BigQueryRetryConfig, RetryOption...)} */
@@ -329,47 +360,64 @@ public class Job extends JobInfo {
       }
     }
 
-    QueryResponse response =
-        waitForQueryResults(
-            DEFAULT_JOB_WAIT_SETTINGS,
-            DEFAULT_RETRY_CONFIG,
-            waitOptions.toArray(new QueryResultsOption[0]));
-
-    // Get the job resource to determine if it has errored.
-    Job job = this;
-    if (job.getStatus() == null || !JobStatus.State.DONE.equals(job.getStatus().getState())) {
-      job = reload();
+    Span getQueryResults = null;
+    if (this.options.isOpenTelemetryTracingEnabled()
+        && this.options.getOpenTelemetryTracer() != null) {
+      getQueryResults =
+          this.options
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.Job.getQueryResults")
+              .setAllAttributes(otelAttributesFromOptions(options))
+              .startSpan();
     }
-    if (job.getStatus() != null && job.getStatus().getError() != null) {
-      throw new BigQueryException(
-          job.getStatus().getExecutionErrors() == null
-              ? ImmutableList.of(job.getStatus().getError())
-              : ImmutableList.copyOf(job.getStatus().getExecutionErrors()));
-    }
+    try (Scope getQueryResultsScope =
+        getQueryResults != null ? getQueryResults.makeCurrent() : null) {
+      QueryResponse response =
+          waitForQueryResults(
+              DEFAULT_JOB_WAIT_SETTINGS,
+              DEFAULT_RETRY_CONFIG,
+              waitOptions.toArray(new QueryResultsOption[0]));
 
-    // If there are no rows in the result, this may have been a DDL query.
-    // Listing table data might fail, such as with CREATE VIEW queries.
-    // Avoid a tabledata.list API request by returning an empty TableResult.
-    if (response.getTotalRows() == 0) {
-      TableResult emptyTableResult =
-          TableResult.newBuilder()
-              .setSchema(response.getSchema())
-              .setJobId(job.getJobId())
-              .setTotalRows(0L)
-              .setPageNoSchema(new PageImpl<FieldValueList>(null, "", null))
-              .build();
-      return emptyTableResult;
-    }
+      // Get the job resource to determine if it has errored.
+      Job job = this;
+      if (job.getStatus() == null || !JobStatus.State.DONE.equals(job.getStatus().getState())) {
+        job = reload();
+      }
+      if (job.getStatus() != null && job.getStatus().getError() != null) {
+        throw new BigQueryException(
+            job.getStatus().getExecutionErrors() == null
+                ? ImmutableList.of(job.getStatus().getError())
+                : ImmutableList.copyOf(job.getStatus().getExecutionErrors()));
+      }
 
-    TableId table =
-        ((QueryJobConfiguration) getConfiguration()).getDestinationTable() == null
-            ? ((QueryJobConfiguration) job.getConfiguration()).getDestinationTable()
-            : ((QueryJobConfiguration) getConfiguration()).getDestinationTable();
-    TableResult tableResult =
-        bigquery.listTableData(
-            table, response.getSchema(), listOptions.toArray(new TableDataListOption[0]));
-    TableResult tableResultWithJobId = tableResult.toBuilder().setJobId(job.getJobId()).build();
-    return tableResultWithJobId;
+      // If there are no rows in the result, this may have been a DDL query.
+      // Listing table data might fail, such as with CREATE VIEW queries.
+      // Avoid a tabledata.list API request by returning an empty TableResult.
+      if (response.getTotalRows() == 0) {
+        TableResult emptyTableResult =
+            TableResult.newBuilder()
+                .setSchema(response.getSchema())
+                .setJobId(job.getJobId())
+                .setTotalRows(0L)
+                .setPageNoSchema(new PageImpl<FieldValueList>(null, "", null))
+                .build();
+        return emptyTableResult;
+      }
+
+      TableId table =
+          ((QueryJobConfiguration) getConfiguration()).getDestinationTable() == null
+              ? ((QueryJobConfiguration) job.getConfiguration()).getDestinationTable()
+              : ((QueryJobConfiguration) getConfiguration()).getDestinationTable();
+      TableResult tableResult =
+          bigquery.listTableData(
+              table, response.getSchema(), listOptions.toArray(new TableDataListOption[0]));
+      TableResult tableResultWithJobId = tableResult.toBuilder().setJobId(job.getJobId()).build();
+      return tableResultWithJobId;
+    } finally {
+      if (getQueryResults != null) {
+        getQueryResults.end();
+      }
+    }
   }
 
   private QueryResponse waitForQueryResults(
@@ -382,7 +430,17 @@ public class Job extends JobInfo {
           "Waiting for query results is supported only for " + Type.QUERY + " jobs");
     }
 
-    try {
+    Span waitForQueryResults = null;
+    if (options.isOpenTelemetryTracingEnabled() && options.getOpenTelemetryTracer() != null) {
+      waitForQueryResults =
+          options
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.Job.waitForQueryResults")
+              .setAllAttributes(otelAttributesFromOptions(resultsOptions))
+              .startSpan();
+    }
+    try (Scope waitForQueryResultsScope =
+        waitForQueryResults != null ? waitForQueryResults.makeCurrent() : null) {
       return BigQueryRetryHelper.runWithRetries(
           new Callable<QueryResponse>() {
             @Override
@@ -401,14 +459,43 @@ public class Job extends JobInfo {
             }
           },
           options.getClock(),
-          bigQueryRetryConfig);
+          bigQueryRetryConfig,
+          options.isOpenTelemetryTracingEnabled(),
+          options.getOpenTelemetryTracer());
     } catch (BigQueryRetryHelper.BigQueryRetryHelperException e) {
       throw BigQueryException.translateAndThrow(e);
+    } finally {
+      if (waitForQueryResults != null) {
+        waitForQueryResults.end();
+      }
     }
   }
 
   private Job waitForJob(RetrySettings waitSettings) throws InterruptedException {
-    try {
+    Span waitForJob = null;
+    if (options.isOpenTelemetryTracingEnabled() && options.getOpenTelemetryTracer() != null) {
+      waitForJob =
+          this.options
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.Job.waitForJob")
+              .setAttribute(
+                  "bq.job.wait_settings.total_timeout",
+                  getFieldAsString(waitSettings.getTotalTimeoutDuration()))
+              .setAttribute(
+                  "bq.job.wait_settings.initial_retry_delay",
+                  getFieldAsString(waitSettings.getInitialRetryDelayDuration()))
+              .setAttribute(
+                  "bq.job.wait_settings.max_retry_delay",
+                  getFieldAsString(waitSettings.getMaxRetryDelayDuration()))
+              .setAttribute(
+                  "bq.job.wait_settings.initial_rpc_timeout",
+                  getFieldAsString(waitSettings.getInitialRpcTimeoutDuration()))
+              .setAttribute(
+                  "bq.job.wait_settings.max_rpc_timeout",
+                  getFieldAsString(waitSettings.getMaxRpcTimeoutDuration()))
+              .startSpan();
+    }
+    try (Scope waitForJobScope = waitForJob != null ? waitForJob.makeCurrent() : null) {
       return RetryHelper.poll(
           new Callable<Job>() {
             @Override
@@ -433,6 +520,10 @@ public class Job extends JobInfo {
           options.getClock());
     } catch (ExecutionException e) {
       throw BigQueryException.translateAndThrow(e);
+    } finally {
+      if (waitForJob != null) {
+        waitForJob.end();
+      }
     }
   }
 
@@ -463,14 +554,31 @@ public class Job extends JobInfo {
    */
   public Job reload(JobOption... options) {
     checkNotDryRun("reload");
-    Job job = bigquery.getJob(getJobId(), options);
-    if (job != null && job.getStatus().getError() != null) {
-      throw new BigQueryException(
-          job.getStatus().getExecutionErrors() == null
-              ? ImmutableList.of(job.getStatus().getError())
-              : ImmutableList.copyOf(job.getStatus().getExecutionErrors()));
+    Span reload = null;
+    if (this.options.isOpenTelemetryTracingEnabled()
+        && this.options.getOpenTelemetryTracer() != null) {
+      reload =
+          this.options
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.Job.reload")
+              .setAllAttributes(otelAttributesFromOptions(options))
+              .startSpan();
     }
-    return job;
+
+    try (Scope reloadScope = reload != null ? reload.makeCurrent() : null) {
+      Job job = bigquery.getJob(getJobId(), options);
+      if (job != null && job.getStatus().getError() != null) {
+        throw new BigQueryException(
+            job.getStatus().getExecutionErrors() == null
+                ? ImmutableList.of(job.getStatus().getError())
+                : ImmutableList.copyOf(job.getStatus().getExecutionErrors()));
+      }
+      return job;
+    } finally {
+      if (reload != null) {
+        reload.end();
+      }
+    }
   }
 
   /**
@@ -492,7 +600,22 @@ public class Job extends JobInfo {
    */
   public boolean cancel() {
     checkNotDryRun("cancel");
-    return bigquery.cancel(getJobId());
+    Span cancel = null;
+    if (options.isOpenTelemetryTracingEnabled() && options.getOpenTelemetryTracer() != null) {
+      cancel =
+          options
+              .getOpenTelemetryTracer()
+              .spanBuilder("com.google.cloud.bigquery.Job.cancel")
+              .startSpan();
+    }
+
+    try (Scope cancelScope = cancel != null ? cancel.makeCurrent() : null) {
+      return bigquery.cancel(getJobId());
+    } finally {
+      if (cancel != null) {
+        cancel.end();
+      }
+    }
   }
 
   private void checkNotDryRun(String op) {
@@ -555,5 +678,20 @@ public class Job extends JobInfo {
 
   static Job fromPb(BigQuery bigquery, com.google.api.services.bigquery.model.Job jobPb) {
     return new Job(bigquery, new JobInfo.BuilderImpl(jobPb));
+  }
+
+  private static Attributes otelAttributesFromOptions(Option... options) {
+    Attributes attributes = Attributes.builder().build();
+    for (Option option : options) {
+      attributes =
+          attributes.toBuilder()
+              .put(option.getRpcOption().toString(), option.getValue().toString())
+              .build();
+    }
+    return attributes;
+  }
+
+  private static String getFieldAsString(Object field) {
+    return field == null ? "null" : field.toString();
   }
 }


### PR DESCRIPTION
The more here refers to `TableDataWriteChannel`. This PR also changes the signature of `BigQueryRetryHelper.runWithRetries()` to include a `boolean` and Otel `Tracer` as parameters.
