### PR TITLE
deps: remove version declaration of open-telemetry-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,15 +59,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- OpenTelemetry -->
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>1.51.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>


### PR DESCRIPTION
opentelemetry-bom is declared in https://github.com/googleapis/sdk-platform-java/blob/71da6c077d745d4c248eb122fcf9920ee0df772f/java-shared-dependencies/third-party-dependencies/pom.xml#L145

Fixes #3854  ☕️