### PR TITLE
chore: Ignore PR limits in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -111,5 +111,7 @@
   "dependencyDashboard": true,
   "dependencyDashboardLabels": [
     "type: process"
-  ]
+  ],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0
 }


### PR DESCRIPTION
This repo is not managed the hermetic build. Hence manually creating a PR to ignore PR limits in renovate.json. Other handwritten repos should be handled by https://github.com/googleapis/sdk-platform-java/pull/3902.