### PR TITLE
fix(bigquery): Prevent Job.waitFor() from hanging on failed query jobs

### DIFF
--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -3393,16 +3393,17 @@ public class ITBigQueryTest {
   public void testSingleStatementsQueryException() throws InterruptedException {
     String invalidQuery =
         String.format("INSERT %s.%s VALUES('3', 10);", DATASET, TABLE_ID.getTable());
-    try {
-      bigquery.create(JobInfo.of(QueryJobConfiguration.of(invalidQuery))).waitFor();
-      fail("BigQueryException was expected");
-    } catch (BigQueryException ex) {
-      assertEquals("invalidQuery", ex.getReason());
-      assertNotNull(ex.getMessage());
-      BigQueryError error = ex.getError();
-      assertEquals("invalidQuery", error.getReason());
-      assertNotNull(error.getMessage());
-    }
+
+    Job completedJob =
+        bigquery.create(JobInfo.of(QueryJobConfiguration.of(invalidQuery))).waitFor();
+
+    assertNotNull(completedJob);
+    assertNotNull(completedJob.getStatus());
+
+    BigQueryError error = completedJob.getStatus().getError();
+    assertNotNull(error);
+    assertEquals("invalidQuery", error.getReason());
+    assertNotNull(error.getMessage());
   }
 
   /* TODO(prasmish): replicate the entire test case for executeSelect */
@@ -3412,16 +3413,17 @@ public class ITBigQueryTest {
         String.format(
             "INSERT %s.%s VALUES('3', 10); DELETE %s.%s where c2=3;",
             DATASET, TABLE_ID.getTable(), DATASET, TABLE_ID.getTable());
-    try {
-      bigquery.create(JobInfo.of(QueryJobConfiguration.of(invalidQuery))).waitFor();
-      fail("BigQueryException was expected");
-    } catch (BigQueryException ex) {
-      assertEquals("invalidQuery", ex.getReason());
-      assertNotNull(ex.getMessage());
-      BigQueryError error = ex.getError();
-      assertEquals("invalidQuery", error.getReason());
-      assertNotNull(error.getMessage());
-    }
+
+    Job completedJob =
+        bigquery.create(JobInfo.of(QueryJobConfiguration.of(invalidQuery))).waitFor();
+
+    assertNotNull(completedJob);
+    assertNotNull(completedJob.getStatus());
+
+    BigQueryError error = completedJob.getStatus().getError();
+    assertNotNull(error);
+    assertEquals("invalidQuery", error.getReason());
+    assertNotNull(error.getMessage());
   }
 
   @Test


### PR DESCRIPTION
When a query job fails and the subsequent `getQueryResults` API call also fails with a retryable error (e.g., `rateLimitExceeded`), the `Job.waitFor()` method would enter a retry loop without checking the underlying job's status. This caused the client to hang indefinitely, only ending when the total timeout was reached.

This fix addresses the issue by intercepting the retryable exception within the `waitForQueryResults` polling loop. Before proceeding with a retry, the code now makes an additional `getJob()` call to check the job's actual status. If the job is already in a terminal `DONE` state, the retry loop is immediately terminated, and the final job status is returned to the user.

A regression test has been added to simulate a similar failure scenario, ensuring the client no longer hangs and correctly returns the failed job.

Fixes: b/451741841