### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,22 +2,22 @@ branches:
     - branch: 1.127.12-sp
       releaseType: java-lts
     - branch: java7
-    - releaseType: java-backport
-      branch: 2.3.x
-    - releaseType: java-backport
-      branch: 2.10.x
-    - releaseType: java-backport
-      branch: 2.19.x
-    - releaseType: java-backport
-      branch: 2.35.x
-    - releaseType: java-backport
-      branch: 2.40.x
-    - releaseType: java-backport
-      branch: 2.48.x
-    - releaseType: java-backport
-      branch: 2.52.x
-    - releaseType: java-backport
-      branch: 2.51.x
+    - branch: 2.3.x
+      releaseType: java-backport
+    - branch: 2.10.x
+      releaseType: java-backport
+    - branch: 2.19.x
+      releaseType: java-backport
+    - branch: 2.35.x
+      releaseType: java-backport
+    - branch: 2.40.x
+      releaseType: java-backport
+    - branch: 2.48.x
+      releaseType: java-backport
+    - branch: 2.52.x
+      releaseType: java-backport
+    - branch: 2.51.x
+      releaseType: java-backport
     - branch: protobuf-4.x-rc
       manifest: true
 handleGHRelease: true


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.