### PR TITLE
chore: Change bigquerystorage upgrade from chore to deps 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,14 +45,6 @@
       ]
     },
     {
-      "semanticCommitType": "deps",
-      "semanticCommitScope": null,
-      "matchPackageNames": [
-        "*",
-        "/^com.google.cloud:google-cloud-bigquerystorage/"
-      ]
-    },
-    {
       "semanticCommitType": "build",
       "semanticCommitScope": "deps",
       "matchPackageNames": [
@@ -68,7 +60,7 @@
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
       "matchPackageNames": [
-        "/^com.google.cloud:google-cloud-bigquery/",
+        "/^com.google.cloud:google-cloud-bigquery$/",
         "/^com.google.cloud:google-cloud-bigtable/",
         "/^com.google.cloud:libraries-bom/",
         "/^com.google.cloud.samples:shared-configuration/"


### PR DESCRIPTION
[deps update from bigquerystorage](https://github.com/googleapis/java-bigquery/pull/4025) was incorrectly marked as `chore(deps)`. This would cause the upgrade not show up in the release notes and also not trigger release please.

This is because the pattern `/^com.google.cloud:google-cloud-bigquery` is configured in renovate.json, which matches both `bigquery` and `bigquerystorage`. However, I believe the original intention is only for `bigquery` update in samples, not for `bigquerystorage` update. 

Fixing the pattern so that the String must ends with `bigquery`.