### PR TITLE
fix: Job.isDone() uses Job.Status.State if available

### DIFF
--- a/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/JobTest.java
+++ b/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/JobTest.java
@@ -157,11 +157,9 @@ public class JobTest {
 
   @Test
   public void testIsDone_True() {
-    BigQuery.JobOption[] expectedOptions = {BigQuery.JobOption.fields(BigQuery.JobField.STATUS)};
     Job job = expectedJob.toBuilder().setStatus(new JobStatus(JobStatus.State.DONE)).build();
-    when(bigquery.getJob(JOB_INFO.getJobId(), expectedOptions)).thenReturn(job);
     assertTrue(job.isDone());
-    verify(bigquery).getJob(JOB_INFO.getJobId(), expectedOptions);
+    verify(bigquery, times(0)).getJob(eq(JOB_INFO.getJobId()), any());
   }
 
   @Test
@@ -176,8 +174,10 @@ public class JobTest {
   @Test
   public void testIsDone_NotExists() {
     BigQuery.JobOption[] expectedOptions = {BigQuery.JobOption.fields(BigQuery.JobField.STATUS)};
+    Job jobWithRunningState =
+        expectedJob.toBuilder().setStatus(new JobStatus(JobStatus.State.RUNNING)).build();
     when(bigquery.getJob(JOB_INFO.getJobId(), expectedOptions)).thenReturn(null);
-    assertTrue(job.isDone());
+    assertTrue(jobWithRunningState.isDone());
     verify(bigquery).getJob(JOB_INFO.getJobId(), expectedOptions);
   }
 


### PR DESCRIPTION
[Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes https://github.com/googleapis/java-bigquery/issues/3672