### PR TITLE
fix: gracefully handle thread interruption in ConnectionImpl to preve…

### DIFF
--- a/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
+++ b/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ConnectionImpl.java
@@ -1069,9 +1069,7 @@ class ConnectionImpl implements Connection {
             }
 
           } catch (Exception e) {
-            if (e instanceof InterruptedException
-                || e.getCause() instanceof InterruptedException
-                || e instanceof com.google.api.gax.rpc.CancelledException) {
+            if (e instanceof InterruptedException || e.getCause() instanceof InterruptedException) {
               // Log silently and let it fall through to 'finally' for cleanup.
               // This is the "graceful shutdown".
               logger.log(


### PR DESCRIPTION
Fixes #3992

Handled InterruptedException in the background thread. This prevents stack traces from polluting stderr during connection.close(), which was causing flakes in strict CI environments (like GraalVM tests). Verified locally that the thread stops correctly without leaks.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigquery/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
