### PR TITLE
chore: Ignore unused declared junit-jupiter-engine error in dependencies check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
             <ignoredUnusedDeclaredDependency>io.netty:netty-common</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.arrow:arrow-memory-netty</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>com.google.api:gax</ignoredUnusedDeclaredDependency>
-            <!-- Ignored because maven-dependency-plugin cannot detect the runtime usage of junit-jupiter-engine for executing JUnit 5 tests. -->
+            <!-- maven-dependency-plugin cannot detect the runtime usage of junit-jupiter-engine for executing JUnit 5+ tests. -->
             <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>


### PR DESCRIPTION
From https://github.com/googleapis/java-bigquery/pull/4042#issuecomment-3686920930

Complains about junit-jupiter-engine as an unused declared dependency. It is needed for running the junit 5.x tests.