### PR TITLE
fix(jdbc): return null for invalid URLs in `connect()` to comply with JDBC spec

### DIFF
--- a/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDriver.java
+++ b/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDriver.java
@@ -165,8 +165,7 @@ public class BigQueryDriver implements Driver {
                 this.toString()));
         return connection;
       } else {
-        throw new IllegalArgumentException(
-            "Invalid URL provided, must start with \"jdbc:bigquery:\"");
+        return null;
       }
     } catch (IOException e) {
       LOG.warning("Getting a warning: " + e.getMessage());

--- a/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDriverTest.java
+++ b/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDriverTest.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigquery.jdbc;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 
 import java.sql.Connection;
 import java.sql.DriverPropertyInfo;
@@ -36,8 +35,8 @@ public class BigQueryDriverTest {
   }
 
   @Test
-  public void testInvalidURLDoesNotConnect() {
-    assertThrows(IllegalArgumentException.class, () -> bigQueryDriver.connect("badURL.com", null));
+  public void testInvalidURLReturnsNull() throws SQLException {
+    assertThat(bigQueryDriver.connect("badURL.com", null)).isNull();
   }
 
   @Test


### PR DESCRIPTION
b/479264130

According to the `java.sql.Driver.connect()` specification, drivers should return `null` instead of throwing an exception when they cannot accept a given URL. This allows `DriverManager` to iterate through all registered drivers until it finds one that can handle the URL.

