### PR TITLE
chore: replace old java team with cloud-sdk-java-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,13 +5,13 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/api-bigquery is the default owner for changes in this repo
-*                       @googleapis/cloud-java-team-teamsync @googleapis/api-bigquery
+*                       @googleapis/cloud-sdk-java-team @googleapis/api-bigquery
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/cloud-java-team-teamsync @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/cloud-sdk-java-team @googleapis/java-samples-reviewers
 
 # Generated snippets should not be owned by samples reviewers
-samples/snippets/generated/      @googleapis/cloud-java-team-teamsync @googleapis/yoshi-java
+samples/snippets/generated/      @googleapis/cloud-sdk-java-team
 
 # JDBC Driver
-google-cloud-bigquery-jdbc/**    @googleapis/bq-developer-tools @googleapis/cloud-java-team-teamsync
+google-cloud-bigquery-jdbc/**    @googleapis/bq-developer-tools @googleapis/cloud-sdk-java-team


### PR DESCRIPTION
Replace old teams with new ones.
b/479542582