### PR TITLE
chore(jdbc): shade bq sdk in jdbc 'all' package

### DIFF
--- a/google-cloud-bigquery-jdbc/pom.xml
+++ b/google-cloud-bigquery-jdbc/pom.xml
@@ -98,7 +98,6 @@
                       <pattern>com</pattern>
                       <shadedPattern>com.google.bqjdbc.shaded.com</shadedPattern>
                       <excludes>
-                        <exclude>com.google.cloud.bigquery.*</exclude>
                         <exclude>com.google.cloud.bigquery.jdbc.*</exclude>
                       </excludes>
                     </relocation>


### PR DESCRIPTION
Remove exclusion `com.google.cloud.bigquery.*` from shaded jar. Hit an issue with local tests that also bring BQ SDK dependency. Given that some deps of SDK are shaded, it creates an incompatibility.

Moving forward, shaded jar is meant to be used when generic JDBC driver is expected. Non-shaded thin jar can be used for specific integrations that can retrieve BQ-specific data rather than use it as a generic JDBC driver.