### PR TITLE
feat(jdbc): enable gRPC Keep-Alive for Storage Read API

### DIFF
--- a/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1063,8 +1063,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
       activeProvider =
           ((InstantiatingGrpcChannelProvider) activeProvider)
               .toBuilder()
-                  .setKeepAliveTime(org.threeten.bp.Duration.ofSeconds(10))
-                  .setKeepAliveTimeout(org.threeten.bp.Duration.ofSeconds(5))
+                  .setKeepAliveTimeDuration(java.time.Duration.ofSeconds(10))
+                  .setKeepAliveTimeoutDuration(java.time.Duration.ofSeconds(5))
                   .setKeepAliveWithoutCalls(true)
                   .build();
     }

--- a/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -360,8 +359,8 @@ public class BigQueryConnectionTest {
       assertTrue(provider instanceof InstantiatingGrpcChannelProvider);
 
       InstantiatingGrpcChannelProvider grpcProvider = (InstantiatingGrpcChannelProvider) provider;
-      assertEquals(Duration.ofSeconds(10).toString(), grpcProvider.getKeepAliveTime().toString());
-      assertEquals(Duration.ofSeconds(5).toString(), grpcProvider.getKeepAliveTimeout().toString());
+      assertEquals(java.time.Duration.ofSeconds(10), grpcProvider.getKeepAliveTimeDuration());
+      assertEquals(java.time.Duration.ofSeconds(5), grpcProvider.getKeepAliveTimeoutDuration());
       assertTrue(grpcProvider.getKeepAliveWithoutCalls());
     }
   }


### PR DESCRIPTION
b/473628902

Enabled gRPC Keep-Alive settings for BigQuery Storage Read API connections in the JDBC driver.

### Changes
*   **BigQueryConnection.java**: Configured the `TransportChannelProvider` with:
    *   `KeepAliveTime`: 10 seconds
    *   `KeepAliveTimeout`: 5 seconds
    *   `KeepAliveWithoutCalls`: true
*   **BigQueryConnectionTest.java**: Added `testBigQueryReadClientKeepAliveSettings`