### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/api-bigquery is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/api-bigquery
+# The @googleapis/bigquery-team is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/bigquery-team
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/cloud-sdk-java-team @googleapis/java-samples-reviewers

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -163,9 +163,9 @@ branchProtectionRules:
       - javadoc
       - unmanaged_dependency_check
 permissionRules:
-  - team: api-bigquery
+  - team: bigquery-team
     permission: admin
-  - team: yoshi-java
+  - team: cloud-sdk-java-team
     permission: push
   - team: yoshi-admins
     permission: admin

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,7 +10,7 @@
   "repo": "googleapis/java-bigquery",
   "repo_short": "java-bigquery",
   "distribution_name": "com.google.cloud:google-cloud-bigquery",
-  "codeowner_team": "@googleapis/api-bigquery",
+  "codeowner_team": "@googleapis/bigquery-team",
   "api_id": "bigquery.googleapis.com",
   "library_type": "GAPIC_MANUAL",
   "requires_billing": true,


### PR DESCRIPTION
This PR replaces @googleapis/api-bigquery with @googleapis/bigquery-team and @googleapis/yoshi-java with @googleapis/cloud-sdk-java-team. b/478003109